### PR TITLE
Don't recursively include .pyc files into tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include MANIFEST.in
 include README.rst
 recursive-include crispy_forms/static *
 recursive-include crispy_forms/templates *
-recursive-include crispy_forms/tests *
+recursive-include crispy_forms/tests *.py


### PR DESCRIPTION
Fix for #200 .pyc files for tests were included if the package is built after tests have been run locally. This patch fixes this.