### PR TITLE
add support for template in data_name attribute

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -415,9 +415,10 @@ class Field(LayoutObject):
             context['wrapper_class'] = self.wrapper_class
 
         # render template in data_name attributes
-        for k, v in self.attrs.items():
-            if k.startswith("data"):
-                v = HTML(v).render(form, form_style, context, template_pack=template_pack)
+        if type(self.attrs) == dict:
+            for k, v in self.attrs.items():
+                if k.startswith("data"):
+                    v = HTML(v).render(form, form_style, context, template_pack=template_pack)
 
         html = ''
         for field in self.fields:

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -414,6 +414,11 @@ class Field(LayoutObject):
         if hasattr(self, 'wrapper_class'):
             context['wrapper_class'] = self.wrapper_class
 
+        # render template in data_name attributes
+        for k, v in self.attrs.items():
+            if k.startswith("data"):
+                v = HTML(v).render(form, form_style, context, template_pack=template_pack)
+
         html = ''
         for field in self.fields:
             html += render_field(field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)


### PR DESCRIPTION
Sometimes we use the html5 `data-name` attribute to communicate data between backend and frontend.
Rendering the template in the `data-name` attribute is a frequent case we met these days.

So I add it support for template rendering with the `data_name` in `Field` layout object.

Thx.