### PR TITLE
Dynamic layout: remove field by its field_name instead of index

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -102,3 +102,4 @@ Contributors
 * Stephen Mitchell <scuml>
 * <pySilver>
 * Christopher Adams <adamsc64>
+* Biel Frontera <bielfrontera>

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -88,6 +88,42 @@ class LayoutObject(object):
 
         return pointers
 
+    def remove_layout_object(self, pointer_index):
+        """
+        Remove a children layout object given by its pointer index. 
+        It will remove the parent layout if it gets empty
+
+        :param pointer_index: field accessor
+        """
+
+        if len(pointer_index) > 1:
+            # call children remove_layout_object
+            child_layout = self.fields[pointer_index[0]]
+            child_layout.remove_layout_object(pointer_index[1:])
+            # remove child_layout if it gets empty
+            if not child_layout.fields:
+                self.pop(pointer_index[0])
+
+        else:
+            # remove field
+            self.pop(pointer_index[0])
+
+    def pop_field(self, field_name):
+        """
+        Remove a field from the layout using its name instead of its index. 
+        It will also remove the parent layout object if its the unique field in this layout.  
+
+        :param field_name: the name of the field to be removed.
+        """
+        pointers = self.get_field_names()
+
+        for pointer in pointers:
+            # pointer is like [[0,1,2], 'field_name1']
+            if pointer[1] == field_name:
+                self.remove_layout_object(pointer[0])
+                break
+
+
 
 class Layout(LayoutObject):
     """

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -90,7 +90,7 @@ class LayoutObject(object):
 
     def remove_layout_object(self, pointer_index):
         """
-        Remove a children layout object given by its pointer index. 
+        Remove a children layout object given by its pointer index.
         It will remove the parent layout if it gets empty
 
         :param pointer_index: field accessor
@@ -108,10 +108,10 @@ class LayoutObject(object):
             # remove field
             self.pop(pointer_index[0])
 
-    def pop_field(self, field_name):
+    def remove_by_fieldname(self, field_name):
         """
-        Remove a field from the layout using its name instead of its index. 
-        It will also remove the parent layout object if its the unique field in this layout.  
+        Remove a field from the layout using its name instead of its index.
+        It will also remove the parent layout object if its the unique field in this layout.
 
         :param field_name: the name of the field to be removed.
         """
@@ -122,7 +122,6 @@ class LayoutObject(object):
             if pointer[1] == field_name:
                 self.remove_layout_object(pointer[0])
                 break
-
 
 
 class Layout(LayoutObject):

--- a/crispy_forms/tests/test_dynamic_api.py
+++ b/crispy_forms/tests/test_dynamic_api.py
@@ -7,7 +7,7 @@ from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
 from crispy_forms.layout import Submit
 from crispy_forms.layout import (
-    Layout, Fieldset, MultiField, HTML, Div, Field
+    Layout, Fieldset, MultiField, HTML, Div, Field, Column
 )
 from crispy_forms.bootstrap import AppendedText
 from crispy_forms.tests.forms import TestForm
@@ -504,6 +504,28 @@ class TestDynamicLayouts(CrispyTestCase):
         layout[0][0] = 'password1'
         self.assertTrue(isinstance(layout[0], Div))
         self.assertEqual(layout[0][0], 'password1')
+
+    def test_remove_layout_field(self):
+        layout = Layout(
+            Fieldset(
+                u'Company Data',
+                'is_company',
+                'email',
+                'password1',
+                'password2',
+                css_id="multifield_info",
+            ),
+            Column(
+                'first_name',
+                'last_name',
+                css_id="column_name",
+            )
+        )
+
+        # Remove email field on the go
+        self.assertEqual(layout.fields[0].fields[1], 'email')
+        layout.remove_by_fieldname('email')
+        self.assertEqual(layout.fields[0].fields[1], 'password1')
 
 
 class TestUniformDynamicLayouts(TestDynamicLayouts):

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -234,6 +234,42 @@ class TestFormLayout(CrispyTestCase):
         html = template.render(c)
         self.assertFalse('email' in html)
 
+    def test_change_layout_dynamically_delete_field_with_pop_field(self):
+        template = loader.get_template_from_string(u"""
+            {% load crispy_forms_tags %}
+            {% crispy form form_helper %}
+        """)
+
+        form = TestForm()
+        form_helper = FormHelper()
+        form_helper.add_layout(
+            Layout(
+                Fieldset(
+                    u'Company Data',
+                    'is_company',
+                    'email',
+                    'password1',
+                    'password2',
+                    css_id = "multifield_info",
+                ),
+                Column(
+                    'first_name',
+                    'last_name',
+                    css_id = "column_name",
+                )
+            )
+        )
+
+        # We remove email field on the go
+        # Layout needs to be adapted for the new form fields
+        del form.fields['email']
+        form_helper.layout.pop_field('email')
+
+        c = Context({'form': form, 'form_helper': form_helper})
+        html = template.render(c)
+        self.assertFalse('email' in html)    
+        self.assertTrue('is_company' in html)    
+
     def test_formset_layout(self):
         TestFormSet = formset_factory(TestForm, extra=3)
         formset = TestFormSet()

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -234,42 +234,6 @@ class TestFormLayout(CrispyTestCase):
         html = template.render(c)
         self.assertFalse('email' in html)
 
-    def test_change_layout_dynamically_delete_field_with_pop_field(self):
-        template = loader.get_template_from_string(u"""
-            {% load crispy_forms_tags %}
-            {% crispy form form_helper %}
-        """)
-
-        form = TestForm()
-        form_helper = FormHelper()
-        form_helper.add_layout(
-            Layout(
-                Fieldset(
-                    u'Company Data',
-                    'is_company',
-                    'email',
-                    'password1',
-                    'password2',
-                    css_id = "multifield_info",
-                ),
-                Column(
-                    'first_name',
-                    'last_name',
-                    css_id = "column_name",
-                )
-            )
-        )
-
-        # We remove email field on the go
-        # Layout needs to be adapted for the new form fields
-        del form.fields['email']
-        form_helper.layout.pop_field('email')
-
-        c = Context({'form': form, 'form_helper': form_helper})
-        html = template.render(c)
-        self.assertFalse('email' in html)    
-        self.assertTrue('is_company' in html)    
-
     def test_formset_layout(self):
         TestFormSet = formset_factory(TestForm, extra=3)
         formset = TestFormSet()

--- a/docs/dynamic_layouts.rst
+++ b/docs/dynamic_layouts.rst
@@ -330,6 +330,40 @@ This is how you would insert a layout object in the second position of the secon
 
     layout[1].insert(1, HTML("<p>whatever</p>"))
 
+
+Removing field by name
+~~~~~~~~~~~~~~~~~~~~~~
+
+Layout can be also maniputated to remove a field using ``remove_by_fieldname`` method, instead using ``pop(index)``. This method removes the parent layout if it gets empty.
+
+Consider this layout::
+
+    Layout(
+        Fieldset(
+            u'Company Data',
+            'company_name',
+            Div(Field('email', css_class="hero")),
+            'password1',
+            'password2',
+        )
+    )
+
+Remove ``email`` and ``password2``::
+
+    layout.remove_by_fieldname('email')
+    layout.remove_by_fieldname('password2')
+
+Layout would turn into::
+
+    Layout(
+        Fieldset(
+            u'Company Data',
+            'company_name',
+            'password1',
+        )
+    )
+
+
 .. Warning ::
 
     Remember always that if you are going to manipulate a helper or layout in a view or any part of your code, you better use an instance level variable.


### PR DESCRIPTION
New two methods at LayoutObject: pop_field(field_name) and remove_layout_object(pointer_index).

Crispy forms documentation says that to remove an object we have to use pop(index) (see http://django-crispy-forms.readthedocs.org/en/d-0/dynamic_layouts.html). But this index is not always easy to get.


Example:

If we have this form (taken from tests):

```python

form = TestForm()
form_helper = FormHelper()
form_helper.add_layout(
    Layout(
        Fieldset(
            u'Company Data',
            'is_company',
            'email',
            'password1',
            'password2',
            css_id = "multifield_info",
        ),
        Column(
            'first_name',
            'last_name',
            css_id = "column_name",
        )
    )
)
```

Now we have to use this code to dynamically delete a field (pop or del):
```python
form.fields.pop('email')
form_helper.layout.fields[0].pop(1) 
```

And with these new functions, we could do:
```python
form.fields.pop('email')
form_helper.layout.pop_field('email')
``` 