### PR TITLE
Add StaticInput for Bootstrap3

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -390,5 +390,25 @@ class UneditableField(Field):
         super(UneditableField, self).__init__(field, *args, **kwargs)
 
 
+class StaticField(Field):
+    """
+    Layout object for rendering fields as static (paragraphs) in bootstrap3
+    Can also add a hidden field to store the value
+
+    Example::
+
+        StaticField('field_name', add_hidden_field=True)
+    """
+    template = "bootstrap3/layout/static_input.html"
+
+    def __init__(self, field, add_hidden_field=False, *args, **kwargs):
+        self.add_hidden_field = add_hidden_field
+        super(StaticField, self).__init__(field, *args, **kwargs)
+
+    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
+        context['add_hidden_field'] = self.add_hidden_field
+        return super(StaticField, self).render(form, form_style, context, template_pack)
+
+
 class InlineField(Field):
     template = "%s/layout/inline_field.html"

--- a/crispy_forms/templates/bootstrap3/layout/static_input.html
+++ b/crispy_forms/templates/bootstrap3/layout/static_input.html
@@ -1,0 +1,12 @@
+{% load crispy_forms_filters %}
+
+<div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
+    <div class="controls {{ field_class }}">
+        <p class="form-control-static" {{ field.field.widget.attrs|flatatt }}>{{ field.value }}</p>
+        {% if add_hidden_field %}
+            <input type="hidden" name="{{ field.html_name }}" id="id_{{ field.html_name }}" value="{{ field.value }}"  />
+        {% endif %}
+        {% include 'bootstrap3/layout/help_text.html' %}
+    </div>
+</div>


### PR DESCRIPTION
Implement a variant of the "uneditable_input" for Bootstrap 3 which is what Bootstrap calls a "static control"  (also see #252)