### PR TITLE
Pyk3 string compatibility

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -79,7 +79,7 @@ class FormActions(LayoutObject):
             self.attrs['class'] = self.attrs.pop('css_class')
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        html = u''
+        html = ''
         for field in self.fields:
             html += render_field(field, form, form_style, context, template_pack=template_pack, **kwargs)
         extra_context = {
@@ -352,7 +352,7 @@ class Alert(Div):
     """
     `Alert` generates markup in the form of an alert dialog
 
-        Alert(content='<strong>Warning!</strong> Best check yo self, you're not looking too good.')
+        Alert(content='<strong>Warning!</strong> Best check yo self, yo're not looking too good.')
     """
     template = "%s/layout/alert.html"
     css_class = "alert"

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from random import randint
 
 from django.template import Context, Template

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -157,7 +157,7 @@ class ButtonHolder(LayoutObject):
         self.template = kwargs.get('template', self.template)
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        html = u''
+        html = ''
         for field in self.fields:
             html += render_field(
                 field, form, form_style, context, template_pack=template_pack, **kwargs
@@ -281,7 +281,7 @@ class Fieldset(LayoutObject):
 
         legend = ''
         if self.legend:
-            legend = u'%s' % Template(text_type(self.legend)).render(context)
+            legend = '%s' % Template(text_type(self.legend)).render(context)
 
         template = self.template % template_pack
         return render_to_string(
@@ -298,8 +298,8 @@ class MultiField(LayoutObject):
     def __init__(self, label, *fields, **kwargs):
         self.fields = list(fields)
         self.label_html = label
-        self.label_class = kwargs.pop('label_class', u'blockLabel')
-        self.css_class = kwargs.pop('css_class', u'ctrlHolder')
+        self.label_class = kwargs.pop('label_class', 'blockLabel')
+        self.css_class = kwargs.pop('css_class', 'ctrlHolder')
         self.css_id = kwargs.pop('css_id', None)
         self.template = kwargs.pop('template', self.template)
         self.field_template = kwargs.pop('field_template', self.field_template)
@@ -312,7 +312,7 @@ class MultiField(LayoutObject):
                 if field in form.errors:
                     self.css_class += " error"
 
-        fields_output = u''
+        fields_output = ''
         field_template = self.field_template % template_pack
         for field in self.fields:
             fields_output += render_field(

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import warnings
 
 from django.conf import settings

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -436,7 +436,13 @@ class Field(LayoutObject):
             extra_context['wrapper_class'] = self.wrapper_class
 
         html = ''
-        template = self.template % template_pack
+        try:
+            template = self.template % template_pack
+        except TypeError:
+            # Could be the case that a field is extended from Layout and
+            # this provide full path to the template name.
+            template = self.template
+
         for field in self.fields:
             html += render_field(
                 field, form, form_style, context,

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -440,7 +440,7 @@ class Field(LayoutObject):
             template = self.template % template_pack
         except TypeError:
             # Could be the case that a field is extended from Layout and
-            # this provide full path to the template name.
+            # this declare the template name without the `%s` string argument.
             template = self.template
 
         for field in self.fields:

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -58,7 +58,7 @@ class TestFormLayout(CrispyTestCase):
                 self.fields['contraseña'] = forms.CharField()
 
             helper = FormHelper()
-            helper.layout = Layout(u'contraseña')
+            helper.layout = Layout('contraseña')
 
         if PY2:
             self.assertRaises(Exception, lambda: render_crispy_form(UnicodeForm()))
@@ -147,19 +147,19 @@ class TestFormLayout(CrispyTestCase):
         form_helper.add_layout(
             Layout(
                 Fieldset(
-                    u'Company Data',
-                    u'is_company',
+                    'Company Data',
+                    'is_company',
                     css_id = "fieldset_company_data",
                     css_class = "fieldsets",
                     title = "fieldset_title",
                     test_fieldset = "123"
                 ),
                 Fieldset(
-                    u'User Data',
-                    u'email',
+                    'User Data',
+                    'email',
                     Row(
-                        u'password1',
-                        u'password2',
+                        'password1',
+                        'password2',
                         css_id = "row_passwords",
                         css_class = "rows",
                     ),
@@ -167,8 +167,8 @@ class TestFormLayout(CrispyTestCase):
                     HTML(u"""
                         {% if flag %}{{ message }}{% endif %}
                     """),
-                    u'first_name',
-                    u'last_name',
+                    'first_name',
+                    'last_name',
                 )
             )
         )
@@ -210,7 +210,7 @@ class TestFormLayout(CrispyTestCase):
         form_helper.add_layout(
             Layout(
                 Fieldset(
-                    u'Company Data',
+                    'Company Data',
                     'is_company',
                     'email',
                     'password1',

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -154,7 +154,7 @@ def flatatt(attrs):
     XML-style pairs.  It is assumed that the keys do not need to be XML-escaped.
     If the passed dictionary is empty, then return an empty string.
     """
-    return u''.join([u' %s="%s"' % (k.replace('_', '-'), conditional_escape(v)) for k, v in attrs.items()])
+    return ''.join([' %s="%s"' % (k.replace('_', '-'), conditional_escape(v)) for k, v in attrs.items()])
 
 
 def render_crispy_form(form, helper=None, context=None):

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -1,4 +1,5 @@
-from __future__ import with_statement
+from __future__ import with_statement, unicode_literals
+
 import inspect
 import logging
 import sys


### PR DESCRIPTION
There are two fixes:

1. Replacing `u''` with `''` to make python3.3 syntax valid, and maintain support for python2

2. Fields templates, could be the case that a field is extended from Layout and this provide full path to the template name.   For example: 'app/custom_field.html' instead of 'app/%s/custom_field.html' where the `%s` argument will be replaced with the template pack in use Django crispy forms should support both cases