### PR TITLE
Fixed bootstrap3 required field class name

### DIFF
--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -11,7 +11,7 @@
     {% endif %}
 	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox and form_show_labels %}
-			<label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+			<label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} required-field{% endif %}">
 				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
 			</label>
 		{% endif %}

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -200,6 +200,9 @@ class BasicNode(template.Node):
         if 'csrf_token' in context:
             response_dict['csrf_token'] = context['csrf_token']
 
+        if 'request' in context:
+            response_dict['request'] = context['request']
+
         return response_dict
 
 


### PR DESCRIPTION
Bootstrap3 expects you to use the class name 'required-field' for required fields instead of 'requiredField' so this simply fixes that.

Thanks,
Nathan Shafer