### PR TITLE
Fix for alignment of stacked checkboxes and radio buttons in Bootstrap 3

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
@@ -5,9 +5,12 @@
     {% include 'bootstrap3/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-        <label class="checkbox{% if inline_class %}-{{ inline_class }}{% endif %}">
+
+      {% if not inline_class %}<div class="checkbox">{% endif %}
+        <label class="{% if inline_class %}checkbox-{{ inline_class }}{% endif %}">
             <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
+      {% if not inline_class %}</div>{% endif %}
     {% endfor %}
 
     {% include 'bootstrap3/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap3/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap3/layout/radioselect.html
@@ -5,9 +5,11 @@
     {% include 'bootstrap3/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-        <label class="radio{% if inline_class %}-{{ inline_class }}{% endif %}">
+      {% if not inline_class %}<div class="radio">{% endif %}
+        <label class="{% if inline_class %}radio-{{ inline_class }}{% endif %}">
             <input type="radio"{% if choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
+      {% if not inline_class %}</div>{% endif %}
     {% endfor %}
 
     {% include 'bootstrap3/layout/help_text.html' %}


### PR DESCRIPTION
Modified layout for checkboxes and radio buttons with Bootstrap 3, so that stacked widgets align with their inline counterparts (as well as other form fields).

### The Problem
Stacked and inline fields do not align:

![Before fix: Stacked and inline fields do not align](http://i.imgur.com/pYm3OBg.png)

...but with the changes in this commit, they will:

![After fix: Stacked and inline fields align](http://i.imgur.com/FlnRMAs.png)

#### Code used for this example

    # Fields
    checkbox_inline = forms.TypedChoiceField(
        label=_('Checkbox Inline'),
        widget=forms.CheckboxSelectMultiple,
        choices=((1, 'Inline 1',), (2, 'Inline 2',), (3, 'Inline 3',), (4, 'Inline 4',),)
    )

    checkbox_stacked = forms.TypedChoiceField(
        label=_('Checkbox Stacked'),
        widget=forms.CheckboxSelectMultiple,
        choices=((1, 'Stacked 1',), (2, 'Stacked 2',), (3, 'Stacked 3',), (4, 'Stacked 4',),)
    )

    radio_inline = forms.TypedChoiceField(
        label=_('Radio Inline'),
        widget=forms.RadioSelect,
        choices=((1, 'Inline 1',), (2, 'Inline 2',), (3, 'Inline 3',), (4, 'Inline 4',),)
    )

    radio_stacked = forms.TypedChoiceField(
        label=_('Radio Stacked'),
        widget=forms.RadioSelect,
        choices=((1, 'Stacked 1',), (2, 'Stacked 2',), (3, 'Stacked 3',), (4, 'Stacked 4',),)
    )

    # Layout Helper
    self.helper.layout = Layout(
        InlineCheckboxes('checkbox_inline'),
        'checkbox_stacked',
        InlineRadios('radio_inline'),
        'radio_stacked',
    )

### The Fix
In accordance with the [specifications](http://getbootstrap.com/css/#forms-controls) in Bootstrap (see section *Checkboxes and radios*) I have moved the `.checkbox` class to a parent `div` element for stacked widgets (only), and kept `.checkbox-inline` for inline elements only.
