### PR TITLE
Update memoize to lru_cache decorator

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -4,7 +4,7 @@ from django.forms import forms
 from django.forms.formsets import BaseFormSet
 from django.template import Context
 from django.template.loader import get_template
-from django.utils.functional import memoize
+from django.utils import lru_cache
 from django.utils.safestring import mark_safe
 from django import template
 
@@ -15,14 +15,15 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 DEBUG = getattr(settings, 'DEBUG', False)
 
 
+@lru_cache.lru_cache(maxsize=None)
 def uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_formset.html' % template_pack)
-uni_formset_template = memoize(uni_formset_template, {}, 1)
 
 
+@lru_cache.lru_cache(maxsize=None)
 def uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_form.html' % template_pack)
-uni_form_template = memoize(uni_form_template, {}, 1)
+
 
 register = template.Library()
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.forms.formsets import BaseFormSet
 from django.template import Context
 from django.template.loader import get_template
-from django.utils.functional import memoize
+from django.utils import lru_cache
 from django import template
 
 from crispy_forms.helper import FormHelper
@@ -203,14 +203,14 @@ class BasicNode(template.Node):
         return response_dict
 
 
+@lru_cache.lru_cache(maxsize=None)
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_formset.html' % template_pack)
-whole_uni_formset_template = memoize(whole_uni_formset_template, {}, 1)
 
 
+@lru_cache.lru_cache(maxsize=None)
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_form.html' % template_pack)
-whole_uni_form_template = memoize(whole_uni_form_template, {}, 1)
 
 
 class CrispyFormNode(BasicNode):

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -8,7 +8,7 @@ from django.forms.forms import BoundField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import conditional_escape
-from django.utils.functional import memoize
+from django.utils import lru_cache
 
 from .base import KeepContext
 from .compatibility import text_type, PY2
@@ -18,11 +18,11 @@ from .compatibility import text_type, PY2
 TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 
 
-# By memoizeing we avoid loading the template every time render_field
+# By caching we avoid loading the template every time render_field
 # is called without a template
+@lru_cache.lru_cache(maxsize=None)
 def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
-default_field_template = memoize(default_field_template, {}, 1)
 
 
 def render_field(


### PR DESCRIPTION
django.utils.functional.memoize function
The function memoize is deprecated and should be replaced by the functools.lru_cache decorator (available from Python 3.2 onwards).

Django ships a backport of this decorator for older Python versions and it’s available at django.utils.lru_cache.lru_cache. The deprecated function will be removed in Django 1.9.