### PR TITLE
Allow extra css_class properties for TabHolder and Tab elements 

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -243,6 +243,11 @@ class TabHolder(ContainerHolder):
         )
     """
     template = '%s/layout/tab.html' % TEMPLATE_PACK
+    
+    def __init__(self, *args, **kwargs):
+        self.css_class_add = kwargs.pop('css_class',"")
+        super(TabHolder, self).__init__(*args, **kwargs)
+
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
         links, content = '', ''
@@ -259,7 +264,7 @@ class TabHolder(ContainerHolder):
             links += tab.render_link()
 
         return render_to_string(self.template, Context({
-            'tabs': self, 'links': links, 'content': content
+            'tabs': self, 'links': links, 'content': content, 'css_class_add':self.css_class_add
         }))
 
 

--- a/crispy_forms/templates/bootstrap3/layout/tab.html
+++ b/crispy_forms/templates/bootstrap3/layout/tab.html
@@ -1,6 +1,6 @@
-<ul{% if tabs.css_id %} id="{{ tabs.css_id }}"{% endif %} class="nav nav-tabs">
+<ul{% if tabs.css_id %} id="{{ tabs.css_id }}"{% endif %} class="nav nav-tabs{% if css_class_add %} {{ css_class_add }}{% endif %}">
     {{ links|safe }}
 </ul>
-<div class="tab-content panel-body">
+<div class="tab-content panel-body{% if css_class_add %} {{ css_class_add }}{% endif %}">
     {{ content|safe }}
 </div>


### PR DESCRIPTION
Specifically done to allow http://openam.github.io/bootstrap-responsive-tabs/ to work, some generalization could allow for the same features.