### PR TITLE
Use string_types instead of basestring

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -8,6 +8,7 @@ from django.template.loader import get_template
 from django.utils.functional import memoize
 from django import template
 
+from crispy_forms.compatibility import string_types
 from crispy_forms.helper import FormHelper
 
 register = template.Library()
@@ -272,7 +273,7 @@ def do_uni_form(parser, token):
     # {% crispy form 'bootstrap' %}
     if (
         helper is not None and
-        isinstance(helper, basestring) and
+        isinstance(helper, string_types) and
         ("'" in helper or '"' in helper)
     ):
         template_pack = helper


### PR DESCRIPTION
... in order to get python 3 compatibility
Otherwise, it's impossible to use django-crispy-forms with python 3

This is similar to pull request #310 but #310 can't pass CI because of other changes.