### PR TITLE
output form.label_suffix or field.label_suffix in labels

### DIFF
--- a/crispy_forms/templates/blocks/label_suffix.html
+++ b/crispy_forms/templates/blocks/label_suffix.html
@@ -1,0 +1,1 @@
+{% if field.label_suffix %}{{ field.label_suffix }}{% elif form %}{{ form.label_suffix|default:"" }}{% endif %}

--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -6,7 +6,7 @@
 	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="control-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox and form_show_labels %}
 			<label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
+				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{% include "blocks/label_suffix.html" %}
 			</label>
 		{% endif %}
 

--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -6,7 +6,7 @@
 	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="control-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox and form_show_labels %}
 			<label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
 			</label>
 		{% endif %}
 

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -12,7 +12,7 @@
 	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox and form_show_labels %}
 			<label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
 			</label>
 		{% endif %}
 

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -12,7 +12,7 @@
 	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox and form_show_labels %}
 			<label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
+				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{% include "blocks/label_suffix.html" %}
 			</label>
 		{% endif %}
 

--- a/crispy_forms/templates/uni_form/field.html
+++ b/crispy_forms/templates/uni_form/field.html
@@ -18,7 +18,7 @@
             {% endif %}
 
             <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/uni_form/field.html
+++ b/crispy_forms/templates/uni_form/field.html
@@ -18,7 +18,7 @@
             {% endif %}
 
             <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{{ field.label_suffix|default:form.lavel_suffix|default:"" }}
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}{% include "blocks/label_suffix.html" %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -8,6 +8,7 @@ from django.utils.functional import memoize
 from django.utils.safestring import mark_safe
 from django import template
 
+from crispy_forms.compatibility import string_types
 from crispy_forms.exceptions import CrispyError
 from crispy_forms.utils import flatatt
 
@@ -90,7 +91,7 @@ def as_crispy_errors(form, template_pack=TEMPLATE_PACK):
 
 
 @register.filter(name='as_crispy_field')
-def as_crispy_field(field, template_pack=TEMPLATE_PACK):
+def as_crispy_field(field, template_pack_or_form=TEMPLATE_PACK):
     """
     Renders a form field like a django-crispy-forms field::
 
@@ -100,12 +101,24 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK):
     or::
 
         {{ form.field|as_crispy_field:"bootstrap" }}
+
+    or if you need to use ``form.label_suffix``::
+
+        {{ form.field|as_crispy_field:form }}
+
     """
     if not isinstance(field, forms.BoundField) and DEBUG:
         raise CrispyError('|as_crispy_field got passed an invalid or inexistent field')
 
+    if not isinstance(template_pack_or_form, string_types):
+        form = template_pack_or_form
+        template_pack = TEMPLATE_PACK
+    else:
+        template_pack = template_pack_or_form
+        form = None
+
     template = get_template('%s/field.html' % template_pack)
-    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True})
+    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True, 'form': form})
     return template.render(c)
 
 


### PR DESCRIPTION
Why crispy forms ignore form.label_suffix ( or field.label_suffix that can be used in Django 1.7)?