### PR TITLE
Use StrictVersion for version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,15 @@ python:
   - "2.6"
   - "2.7"
   - "3.3"
+  - "3.4"
 env:
   - DJANGO=1.3.7
   - DJANGO=1.4.5
   - DJANGO=1.5.1
+  - DJANGO=1.4.18
+  - DJANGO=1.5.12
+  - DJANGO=1.6.10
+  - DJANGO=1.7.3
 install:
   - pip install Django==$DJANGO
   - pip install "file://`pwd`#egg=django-crispy-forms[tests]"
@@ -21,3 +26,19 @@ matrix:
       env: DJANGO=1.4.5
     - python: "3.3"
       env: DJANGO=1.3.7
+    - python: "3.4"
+      env: DJANGO=1.4.5
+    - python: "3.4"
+      env: DJANGO=1.3.7
+    - python: "3.3"
+      env: DJANGO=1.4.18
+    - python: "3.4"
+      env: DJANGO=1.4.18
+    - python: 2.6
+      env: DJANGO=1.7.3
+    - python: 3.3
+      env: DJANGO=1.5.12
+    - python: 3.4
+      env: DJANGO=1.5.12
+    - python: 3.4
+      env: DJANGO=1.6.10

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -7,7 +7,7 @@ from django.template import Context
 from django.template.loader import get_template
 from django.utils.functional import memoize
 from django import template
-
+from crispy_forms.compatibility import string_types
 from crispy_forms.helper import FormHelper
 
 register = template.Library()
@@ -272,7 +272,7 @@ def do_uni_form(parser, token):
     # {% crispy form 'bootstrap' %}
     if (
         helper is not None and
-        isinstance(helper, basestring) and
+        isinstance(helper, string_types) and
         ("'" in helper or '"' in helper)
     ):
         template_pack = helper

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import re
-
+from distutils.version import StrictVersion
 import django
 from django import forms
 from django.conf import settings
@@ -260,15 +260,15 @@ class TestFormLayout(CrispyTestCase):
         )
 
         # Check formset fields
-        django_version = django.get_version()
-        if django_version < '1.5':
+        django_version = StrictVersion(django.get_version())
+        if django_version < StrictVersion('1.5'):
             self.assertEqual(html.count(
                 'type="hidden" name="form-TOTAL_FORMS" value="3" id="id_form-TOTAL_FORMS"'
             ), 1)
             self.assertEqual(html.count(
                 'type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS"'
             ), 1)
-            if (django_version >= '1.4' and django_version < '1.4.4') or django_version < '1.3.6':
+            if (django_version >= StrictVersion('1.4') and django_version < StrictVersion('1.4.4')) or django_version < StrictVersion('1.3.6'):
                 self.assertEqual(html.count(
                     'type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS"'
                 ), 1)
@@ -319,15 +319,15 @@ class TestFormLayout(CrispyTestCase):
         self.assertEqual(html.count("id_form-1-id"), 1)
         self.assertEqual(html.count("id_form-2-id"), 1)
 
-        django_version = django.get_version()
-        if django_version < '1.5':
+        django_version = StrictVersion(django.get_version())
+        if django_version < StrictVersion('1.5'):
             self.assertEqual(html.count(
                 'type="hidden" name="form-TOTAL_FORMS" value="3" id="id_form-TOTAL_FORMS"'
             ), 1)
             self.assertEqual(html.count(
                 'type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS"'
             ), 1)
-            if (django_version >= '1.4' and django_version < '1.4.4') or django_version < '1.3.6':
+            if (django_version >= StrictVersion('1.4') and django_version < StrictVersion('1.4.4')) or django_version < StrictVersion('1.3.6'):
                 self.assertEqual(html.count(
                     'type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS"'
                 ), 1)


### PR DESCRIPTION
test_layout.py includes django version comparisons in test_formset_layout() and test_modelformset_layout().  

    django_version = django.get_version()
    if django_version < '1.5':

With django versions 1.4.10 through 1.4.16 (most current), the simple comparison of strings incorrectly determines these version are 'less than' 1.4.4, and the tests fail.

I have modified these comparisons to use the StrictVersion class found in distutils.  The comparisons, and the tests, are now successful.  

    django_version = StrictVersion(django.get_version())
    if django_version < StrictVersion('1.5'):