### PR TITLE
Python 3 basestring error

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import platform
 from copy import copy
 
 from django.conf import settings
@@ -9,6 +10,10 @@ from django.utils.functional import memoize
 from django import template
 
 from crispy_forms.helper import FormHelper
+
+py_majversion, py_minversion, py_revversion = platform.python_version_tuple()
+if py_majversion != '2':
+    basestring = (str, bytes)
 
 register = template.Library()
 # We import the filters, so they are available when doing load crispy_forms_tags


### PR DESCRIPTION
Fixing NameError: global name 'basestring' is not defined in Python 3.3. See https://travis-ci.org/maraujop/django-crispy-forms/jobs/48339716