### PR TITLE
include import statement for AJAX section

### DIFF
--- a/docs/crispy_tag_forms.rst
+++ b/docs/crispy_tag_forms.rst
@@ -232,6 +232,8 @@ One easy way to validate a crispy-form through AJAX and re-render the resulting 
 
 Our server side code could be::
 
+    from crispy_forms.utils import render_crispy_form
+    
     @jsonview
     def save_example_form(request):
         form = ExampleForm(request.POST or None) 


### PR DESCRIPTION
The documentation in the AJAX section doesn't specify how to import the `render_crispy_form` function, just adding it in to make it clearer.