### PR TITLE
Render help and errors outside label element

### DIFF
--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -24,8 +24,8 @@
                     <label for="{{ field.id_for_label }}" class="checkbox {% if field.field.required %}requiredField{% endif %}">
                         {% crispy_field field %}
                         {{ field.label|safe }}
-                        {% include 'bootstrap/layout/help_text_and_errors.html' %}
                     </label>
+                    {% include 'bootstrap/layout/help_text_and_errors.html' %}
                 {% else %}
                     {% crispy_field field %}
                     {% include 'bootstrap/layout/help_text_and_errors.html' %}

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -29,8 +29,8 @@
                 <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
                     {% crispy_field field %}
                     {{ field.label|safe }}
-                    {% include 'bootstrap3/layout/help_text_and_errors.html' %}
                 </label>
+                {% include 'bootstrap3/layout/help_text_and_errors.html' %}
             {% else %}
                 <div class="controls {{ field_class }}">
                     {% crispy_field field %}


### PR DESCRIPTION
I believe you shouldn't render help texts and errors within a label element. Clicking on a label changes the state of the checkbox and clicking on a help texts or error shouldn't change the state of the checkbox.

Keep up the good work I'm enjoying using crispy forms :+1:

Kinder regards,
Cees van Wieringen.