### PR TITLE
Add unique css_id to AccordionGroup()

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -311,6 +311,9 @@ class AccordionGroup(Container):
     template = "%s/accordion-group.html"
     data_parent = ""  # accordion parent div id.
 
+    def __init__(self, name, *fields, **kwargs):
+        super(AccordionGroup, self).__init__(*fields, **kwargs)
+        self.css_id = "-".join([self.name, text_type(randint(1000, 9999))])
 
 class Accordion(ContainerHolder):
     """

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -199,7 +199,7 @@ class Container(Div):
         self._active_originally_included = "active" in kwargs
         self.active = kwargs.pop("active", False)
         if not self.css_id:
-            self.css_id = slugify(self.name)
+            self.css_id = "-".join([slugify(self.name), text_type(randint(1000, 9999))])
 
     def __contains__(self, field_name):
         """


### PR DESCRIPTION
Unique css_id on AccordionGroup is needed if Accordion is used with formset. If not, each Accordions are tied with other forms Accordions and cannot be open/close individually.