### PR TITLE
Add unique css_id to AccordionGroup for consistency with formset

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -199,7 +199,7 @@ class Container(Div):
         self._active_originally_included = "active" in kwargs
         self.active = kwargs.pop("active", False)
         if not self.css_id:
-            self.css_id = slugify(self.name)
+            self.css_id = "-".join([slugify(self.name), text_type(randint(1000, 9999))])
 
     def __contains__(self, field_name):
         """


### PR DESCRIPTION
Unique css_id on AccordionGroup is needed if Accordion is used with formset. If not, each Accordions are tied with other forms Accordions and cannot be open/close individually.

Maybe it's not the best way to achieve it, but I add the unique css_id through the Container()