### PR TITLE
Again the lru_cache

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,13 +1,12 @@
 from random import randint
 
-from django.template import Context, Template
+from django.template import Template
 from django.template.loader import render_to_string
 from django.template.defaultfilters import slugify
 
 from .compatibility import text_type
 from .layout import LayoutObject, Field, Div
 from .utils import render_field, flatatt, TEMPLATE_PACK
-
 
 
 class PrependedAppendedText(Field):
@@ -22,8 +21,10 @@ class PrependedAppendedText(Field):
 
         self.input_size = None
         css_class = kwargs.get('css_class', '')
-        if css_class.find('input-lg') != -1: self.input_size = 'input-lg'
-        if css_class.find('input-sm') != -1: self.input_size = 'input-sm'
+        if css_class.find('input-lg') != -1:
+            self.input_size = 'input-lg'
+        if css_class.find('input-sm') != -1:
+            self.input_size = 'input-sm'
 
         super(PrependedAppendedText, self).__init__(field, *args, **kwargs)
 
@@ -31,7 +32,7 @@ class PrependedAppendedText(Field):
         extra_context = {
             'crispy_appended_text': self.appended_text,
             'crispy_prepended_text': self.prepended_text,
-            'input_size' : self.input_size,
+            'input_size': self.input_size,
             'active': getattr(self, "active", False)
         }
         template = self.template % template_pack

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -22,5 +22,7 @@ try:
 except ImportError:
     from django.utils.functional import memoize
 
-    def lru_cache(function):
-        return memoize({}, 1)(function)
+    def lru_cache():
+        def decorator(function, cache_dict={}):
+            return memoize(function, cache_dict, 1)
+        return decorator

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -20,6 +20,7 @@ try:
     # avoid RemovedInDjango19Warning by using lru_cache where available
     from django.utils.lru_cache import lru_cache
 except ImportError:
-    import functools
     from django.utils.functional import memoize
-    lru_cache = functools.partial(memoize, cache={}, num_args=1)
+
+    def lru_cache(function):
+        return memoize({}, 1)(function)

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -19,6 +19,7 @@ else:
 try:
     # avoid RemovedInDjango19Warning by using lru_cache where available
     from django.utils.lru_cache import lru_cache
+
     def memoize(function, *args):
         return lru_cache()(function)
 except:

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -20,4 +20,6 @@ try:
     # avoid RemovedInDjango19Warning by using lru_cache where available
     from django.utils.lru_cache import lru_cache
 except ImportError:
-    from django.utils.functional import memoize as lru_cache
+    import functools
+    from django.utils.functional import memoize
+    lru_cache = functools.partial(memoize, cache={}, num_args=1)

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -19,8 +19,5 @@ else:
 try:
     # avoid RemovedInDjango19Warning by using lru_cache where available
     from django.utils.lru_cache import lru_cache
-
-    def memoize(function, *args):
-        return lru_cache()(function)
-except:
-    from django.utils.functional import memoize
+except ImportError:
+    from django.utils.functional import memoize as lru_cache

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,7 +1,5 @@
-import warnings
-
 from django.conf import settings
-from django.template import Context, Template
+from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -23,7 +23,7 @@ class LayoutSlice(object):
         """
         if args:
             if isinstance(fields, list):
-                fields= tuple(fields)
+                fields = tuple(fields)
             else:
                 fields = (fields,)
 

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -181,4 +181,3 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
             raise TypeError("Expected a prepend and/or append argument")
 
     return template.render(context)
-

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -14,9 +14,11 @@ from crispy_forms.utils import flatatt
 TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 DEBUG = getattr(settings, 'DEBUG', False)
 
+
 def uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_formset.html' % template_pack)
 uni_formset_template = memoize(uni_formset_template, {}, 1)
+
 
 def uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_form.html' % template_pack)

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -15,12 +15,12 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 DEBUG = getattr(settings, 'DEBUG', False)
 
 
-@lru_cache
+@lru_cache()
 def uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_formset.html' % template_pack)
 
 
-@lru_cache
+@lru_cache()
 def uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_form.html' % template_pack)
 

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -7,7 +7,7 @@ from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 from django import template
 
-from crispy_forms.compatibility import memoize
+from crispy_forms.compatibility import lru_cache
 from crispy_forms.exceptions import CrispyError
 from crispy_forms.utils import flatatt
 
@@ -15,14 +15,14 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 DEBUG = getattr(settings, 'DEBUG', False)
 
 
+@lru_cache()
 def uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_formset.html' % template_pack)
-uni_formset_template = memoize(uni_formset_template, {}, 1)
 
 
+@lru_cache()
 def uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_form.html' % template_pack)
-uni_form_template = memoize(uni_form_template, {}, 1)
 
 register = template.Library()
 

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -15,12 +15,12 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 DEBUG = getattr(settings, 'DEBUG', False)
 
 
-@lru_cache()
+@lru_cache
 def uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_formset.html' % template_pack)
 
 
-@lru_cache()
+@lru_cache
 def uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/uni_form.html' % template_pack)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -203,12 +203,12 @@ class BasicNode(template.Node):
         return response_dict
 
 
-@lru_cache()
+@lru_cache
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_formset.html' % template_pack)
 
 
-@lru_cache()
+@lru_cache
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_form.html' % template_pack)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -203,12 +203,12 @@ class BasicNode(template.Node):
         return response_dict
 
 
-@lru_cache
+@lru_cache()
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_formset.html' % template_pack)
 
 
-@lru_cache
+@lru_cache()
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_form.html' % template_pack)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -8,8 +8,7 @@ from django.template.loader import get_template
 from django import template
 
 from crispy_forms.helper import FormHelper
-from crispy_forms.compatibility import memoize, string_types
-
+from crispy_forms.compatibility import lru_cache, string_types
 
 register = template.Library()
 # We import the filters, so they are available when doing load crispy_forms_tags
@@ -204,14 +203,14 @@ class BasicNode(template.Node):
         return response_dict
 
 
+@lru_cache()
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_formset.html' % template_pack)
-whole_uni_formset_template = memoize(whole_uni_formset_template, {}, 1)
 
 
+@lru_cache()
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_form.html' % template_pack)
-whole_uni_form_template = memoize(whole_uni_form_template, {}, 1)
 
 
 class CrispyFormNode(BasicNode):

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -203,9 +203,11 @@ class BasicNode(template.Node):
 
         return response_dict
 
+
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_formset.html' % template_pack)
 whole_uni_formset_template = memoize(whole_uni_formset_template, {}, 1)
+
 
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
     return get_template('%s/whole_uni_form.html' % template_pack)

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -15,11 +15,13 @@ from .compatibility import text_type, PY2, memoize
 
 TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 
+
 # By memoizeing we avoid loading the template every time render_field
 # is called without a template
 def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
 default_field_template = memoize(default_field_template, {}, 1)
+
 
 def set_hidden(widget):
     '''
@@ -31,6 +33,7 @@ def set_hidden(widget):
     widget.input_type = 'hidden'
     if not widget.is_hidden:
         widget.is_hidden = True
+
 
 def render_field(
     field, form, form_style, context, template=None, labelclass=None,

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -18,7 +18,7 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 
 # By caching we avoid loading the template every time render_field
 # is called without a template
-@lru_cache
+@lru_cache()
 def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
 

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -9,18 +9,18 @@ from django.template.loader import get_template
 from django.utils.html import conditional_escape
 
 from .base import KeepContext
-from .compatibility import text_type, PY2, memoize
+from .compatibility import lru_cache, text_type, PY2
 
 # Global field template, default template used for rendering a field.
 
 TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 
 
-# By memoizeing we avoid loading the template every time render_field
+# By caching we avoid loading the template every time render_field
 # is called without a template
+@lru_cache()
 def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
-default_field_template = memoize(default_field_template, {}, 1)
 
 
 def set_hidden(widget):

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -18,7 +18,7 @@ TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
 
 # By caching we avoid loading the template every time render_field
 # is called without a template
-@lru_cache()
+@lru_cache
 def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
 


### PR DESCRIPTION
The arguments of lru_cache decorator don't match those of memoize. So this pull request contains an alternative code to manage lru_cache vs memoize used in production. My idea is that newest Django API should be the first to try, and the code should looks like it is always using the newest API.