### PR TITLE
Upgrade test suite to work with Django 1.8

### DIFF
--- a/crispy_forms/tests/base.py
+++ b/crispy_forms/tests/base.py
@@ -22,13 +22,9 @@ class CrispyTestCase(TestCase):
         })
         self.__overriden_settings.enable()
 
-        # resetting template loaders cache
-        self.__template_source_loaders = loader.template_source_loaders
-        loader.template_source_loaders = None
 
     def tearDown(self):
-        loader.template_source_loaders = self.__template_source_loaders
-        self.__overriden_settings.disable()
+        pass
 
     @property
     def current_template_pack(self):

--- a/crispy_forms/tests/runtests_bootstrap.py
+++ b/crispy_forms/tests/runtests_bootstrap.py
@@ -9,24 +9,23 @@ parent = os.path.dirname(os.path.dirname(os.path.dirname(
 sys.path.insert(0, parent)
 
 import django
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.conf import settings
-
 settings.CRISPY_TEMPLATE_PACK = 'bootstrap'
 
 
 def runtests():
     if hasattr(django, 'setup'):
         django.setup()
-    return DjangoTestSuiteRunner(failfast=False).run_tests([
-        'crispy_forms.TestBasicFunctionalityTags',
-        'crispy_forms.TestFormHelper',
-        'crispy_forms.TestBootstrapFormHelper',
-        'crispy_forms.TestFormLayout',
-        'crispy_forms.TestBootstrapFormLayout',
-        'crispy_forms.TestLayoutObjects',
-        'crispy_forms.TestBootstrapLayoutObjects',
-        'crispy_forms.TestDynamicLayouts',
+    return DiscoverRunner(failfast=False).run_tests([
+        'crispy_forms.tests.TestBasicFunctionalityTags',
+        'crispy_forms.tests.TestFormHelper',
+        'crispy_forms.tests.TestBootstrapFormHelper',
+        'crispy_forms.tests.TestFormLayout',
+        'crispy_forms.tests.TestBootstrapFormLayout',
+        'crispy_forms.tests.TestLayoutObjects',
+        'crispy_forms.tests.TestBootstrapLayoutObjects',
+        'crispy_forms.tests.TestDynamicLayouts',
     ], verbosity=1, interactive=True)
 
 

--- a/crispy_forms/tests/runtests_bootstrap3.py
+++ b/crispy_forms/tests/runtests_bootstrap3.py
@@ -9,7 +9,7 @@ parent = os.path.dirname(os.path.dirname(os.path.dirname(
 sys.path.insert(0, parent)
 
 import django
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.conf import settings
 
 settings.CRISPY_TEMPLATE_PACK = 'bootstrap3'
@@ -18,17 +18,17 @@ settings.CRISPY_TEMPLATE_PACK = 'bootstrap3'
 def runtests():
     if hasattr(django, 'setup'):
         django.setup()
-    return DjangoTestSuiteRunner(failfast=False).run_tests([
-        'crispy_forms.TestBasicFunctionalityTags',
-        'crispy_forms.TestFormHelper',
-        'crispy_forms.TestBootstrapFormHelper',
-        'crispy_forms.TestBootstrap3FormHelper',
-        'crispy_forms.TestFormLayout',
-        'crispy_forms.TestBootstrapFormLayout',
-        'crispy_forms.TestBootstrap3FormLayout',
-        'crispy_forms.TestLayoutObjects',
-        'crispy_forms.TestBootstrapLayoutObjects',
-        'crispy_forms.TestDynamicLayouts',
+    return DiscoverRunner(failfast=False).run_tests([
+        'crispy_forms.tests.TestBasicFunctionalityTags',
+        'crispy_forms.tests.TestFormHelper',
+        'crispy_forms.tests.TestBootstrapFormHelper',
+        'crispy_forms.tests.TestBootstrap3FormHelper',
+        'crispy_forms.tests.TestFormLayout',
+        'crispy_forms.tests.TestBootstrapFormLayout',
+        'crispy_forms.tests.TestBootstrap3FormLayout',
+        'crispy_forms.tests.TestLayoutObjects',
+        'crispy_forms.tests.TestBootstrapLayoutObjects',
+        'crispy_forms.tests.TestDynamicLayouts',
     ], verbosity=1, interactive=True)
 
 

--- a/crispy_forms/tests/runtests_uniform.py
+++ b/crispy_forms/tests/runtests_uniform.py
@@ -9,7 +9,7 @@ parent = os.path.dirname(os.path.dirname(os.path.dirname(
 sys.path.insert(0, parent)
 
 import django
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.conf import settings
 settings.CRISPY_TEMPLATE_PACK = 'uni_form'
 
@@ -17,15 +17,15 @@ settings.CRISPY_TEMPLATE_PACK = 'uni_form'
 def runtests():
     if hasattr(django, 'setup'):
         django.setup()
-    return DjangoTestSuiteRunner(failfast=False).run_tests([
-        'crispy_forms.TestBasicFunctionalityTags',
-        'crispy_forms.TestFormHelper',
-        'crispy_forms.TestUniformFormHelper',
-        'crispy_forms.TestFormLayout',
-        'crispy_forms.TestUniformFormLayout',
-        'crispy_forms.TestLayoutObjects',
-        'crispy_forms.TestDynamicLayouts',
-        'crispy_forms.TestUniformDynamicLayouts',
+    return DiscoverRunner(failfast=False).run_tests([
+        'crispy_forms.tests.TestBasicFunctionalityTags',
+        'crispy_forms.tests.TestFormHelper',
+        'crispy_forms.tests.TestUniformFormHelper',
+        'crispy_forms.tests.TestFormLayout',
+        'crispy_forms.tests.TestUniformFormLayout',
+        'crispy_forms.tests.TestLayoutObjects',
+        'crispy_forms.tests.TestDynamicLayouts',
+        'crispy_forms.tests.TestUniformDynamicLayouts',
     ], verbosity=1, interactive=True)
 
 

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from django.forms.models import formset_factory
 from django.middleware.csrf import _get_new_csrf_key
 from django.template import (
-    loader, TemplateSyntaxError, Context
+    TemplateSyntaxError, Context, Engine
 )
 from django.utils.translation import ugettext_lazy as _
 
@@ -37,7 +37,7 @@ class TestFormHelper(CrispyTestCase):
         form_helper.add_input(Hidden('my-hidden', 'Hidden'))
         form_helper.add_input(Button('my-button', 'Button'))
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -76,7 +76,7 @@ class TestFormHelper(CrispyTestCase):
         form_helper.form_action = 'simpleAction'
         form_helper.form_error_title = 'ERRORS'
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy testForm form_helper %}
         """)
@@ -115,7 +115,7 @@ class TestFormHelper(CrispyTestCase):
         form.helper.form_show_errors = True
         form.is_valid()
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy testForm %}
         """)
@@ -202,7 +202,7 @@ class TestFormHelper(CrispyTestCase):
         self.assertEqual(helper['form_id'], 'test-form')
 
     def test_without_helper(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form %}
         """)
@@ -221,7 +221,7 @@ class TestFormHelper(CrispyTestCase):
         override_pack = current_pack == 'uni_form' and 'bootstrap' or 'uni_form'
 
         # {% crispy form 'template_pack_name' %}
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {%% load crispy_forms_tags %%}
             {%% crispy form "%s" %%}
         """ % override_pack)
@@ -238,7 +238,7 @@ class TestFormHelper(CrispyTestCase):
         override_pack = current_pack == 'uni_form' and 'bootstrap' or 'uni_form'
 
         # {% crispy form helper 'template_pack_name' %}
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {%% load crispy_forms_tags %%}
             {%% crispy form form_helper "%s" %%}
         """ % override_pack)
@@ -252,7 +252,7 @@ class TestFormHelper(CrispyTestCase):
 
     def test_template_pack_override_wrong(self):
         try:
-            loader.get_template_from_string(u"""
+            Engine().from_string(u"""
                 {% load crispy_forms_tags %}
                 {% crispy form 'foo' %}
             """)
@@ -260,7 +260,7 @@ class TestFormHelper(CrispyTestCase):
             pass
 
     def test_invalid_helper(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -275,7 +275,7 @@ class TestFormHelper(CrispyTestCase):
         del settings.CRISPY_FAIL_SILENTLY
 
     def test_formset_with_helper_without_layout(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy testFormSet formset_helper %}
         """)
@@ -309,7 +309,7 @@ class TestFormHelper(CrispyTestCase):
 
     def test_CSRF_token_POST_form(self):
         form_helper = FormHelper()
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -325,7 +325,7 @@ class TestFormHelper(CrispyTestCase):
     def test_CSRF_token_GET_form(self):
         form_helper = FormHelper()
         form_helper.form_method = 'GET'
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -9,7 +9,7 @@ from django.forms.models import formset_factory, modelformset_factory
 from django.middleware.csrf import _get_new_csrf_key
 from django.shortcuts import render_to_response
 from django.template import (
-    Context, RequestContext, loader
+    Context, RequestContext, Engine
 )
 from django.test import RequestFactory
 from django.utils.translation import ugettext_lazy as _
@@ -41,7 +41,7 @@ class TestFormLayout(CrispyTestCase):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -79,7 +79,7 @@ class TestFormLayout(CrispyTestCase):
             'first_name',
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -95,7 +95,7 @@ class TestFormLayout(CrispyTestCase):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -113,7 +113,7 @@ class TestFormLayout(CrispyTestCase):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -129,7 +129,7 @@ class TestFormLayout(CrispyTestCase):
         form = ExampleForm()
         form2 = TestForm()
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {{ form.as_ul }}
             {% crispy form2 %}
@@ -172,7 +172,7 @@ class TestFormLayout(CrispyTestCase):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -199,7 +199,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertTrue('testLink' in html)
 
     def test_change_layout_dynamically_delete_field(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form_helper %}
         """)
@@ -358,7 +358,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertEqual(html.count('password'), 0)
 
     def test_i18n(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form form.helper %}
         """)
@@ -455,7 +455,7 @@ class TestUniformFormLayout(TestFormLayout):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
                 {% load crispy_forms_tags %}
                 {% crispy form form_helper %}
             """)
@@ -508,7 +508,7 @@ class TestUniformFormLayout(TestFormLayout):
             )
         )
 
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
                 {% load crispy_forms_tags %}
                 {% crispy form form_helper %}
             """)

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -2,7 +2,7 @@
 import re
 
 from django import forms
-from django.template import loader, Context
+from django.template import Context, Engine
 from django.utils.translation import ugettext as _
 from django.utils.translation import activate, deactivate
 
@@ -23,7 +23,7 @@ from crispy_forms.utils import render_crispy_form
 class TestLayoutObjects(CrispyTestCase):
 
     def test_multiwidget_field(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy form %}
         """)
@@ -51,7 +51,7 @@ class TestLayoutObjects(CrispyTestCase):
         self.assertEqual(html.count('type="hidden"'), 1)
 
     def test_field_type_hidden(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {% crispy test_form %}
         """)

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -2,17 +2,16 @@
 from django.conf import settings
 from django.forms.forms import BoundField
 from django.forms.models import formset_factory
-from django.template import loader, Context
+from django.template import Context, Engine
 
 from .base import CrispyTestCase
 from .forms import TestForm
 from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 
-
 class TestBasicFunctionalityTags(CrispyTestCase):
     def test_as_crispy_errors_form_without_non_field_errors(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {{ form|as_crispy_errors }}
         """)
@@ -24,7 +23,7 @@ class TestBasicFunctionalityTags(CrispyTestCase):
         self.assertFalse("errorMsg" in html or "alert" in html)
 
     def test_as_crispy_errors_form_with_non_field_errors(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {{ form|as_crispy_errors }}
         """)
@@ -38,7 +37,7 @@ class TestBasicFunctionalityTags(CrispyTestCase):
         self.assertFalse("<h3>" in html)
 
     def test_crispy_filter_with_form(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {{ form|crispy }}
         """)
@@ -50,7 +49,7 @@ class TestBasicFunctionalityTags(CrispyTestCase):
         self.assertEqual(html.count('<label'), 7)
 
     def test_crispy_filter_with_formset(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_tags %}
             {{ testFormset|crispy }}
         """)
@@ -68,7 +67,7 @@ class TestBasicFunctionalityTags(CrispyTestCase):
         self.assertTrue('form-MAX_NUM_FORMS' in html)
 
     def test_classes_filter(self):
-        template = loader.get_template_from_string(u"""
+        template = Engine().from_string(u"""
             {% load crispy_forms_field %}
             {{ testField|classes }}
         """)
@@ -81,7 +80,7 @@ class TestBasicFunctionalityTags(CrispyTestCase):
 
     def test_crispy_field_and_class_converters(self):
         if hasattr(settings, 'CRISPY_CLASS_CONVERTERS'):
-            template = loader.get_template_from_string(u"""
+            template = Engine().from_string(u"""
                 {% load crispy_forms_field %}
                 {% crispy_field testField 'class' 'error' %}
             """)

--- a/crispy_forms/tests/urls.py
+++ b/crispy_forms/tests/urls.py
@@ -4,7 +4,15 @@ if django.get_version() >= '1.5':
     from django.conf.urls import patterns, url
 else:
     from django.conf.urls.defaults import patterns, url
+from django.http import HttpResponse
+
+
+def simpleAction(request):
+    return HttpResponse()
+
 
 urlpatterns = patterns('',
-    url(r'^simple/action/$', 'simpleAction', name = 'simpleAction'),
+    url(r'^simple/action/$', 'crispy_forms.tests.urls.simpleAction', name = 'simpleAction'),
 )
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
--i http://simple.crate.io/
 django


### PR DESCRIPTION
There have been several changes in Django 1.8 that break backward compatibility, causing the test suite in crispy forms to not run correctly. These changes have been deprecated since Django 1.6, but only removed in Django 1.8. 

For more info: 

https://docs.djangoproject.com/en/1.8/releases/1.6/#new-test-runner
https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#get-template-from-string

This pull request added these changes. However, the tests might not work if used with earlier versions of Django (have not tested with 1.7).

I'll leave it up to you @maraujop to decide how to go forward with this. If you'd like any changes to comply with 1.7 please let me know and I'll add some commits.

(Also, I use crispy-forms at work, and we're planning to upgrade to 1.8 soon. Let me know if you need help with maintaining and upgrading it)