### PR TITLE
Add wheel and twine dependencies for PyPI uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django
+twine==1.5.0
 wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django
+wheel==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import crispy_forms
 
 from setuptools import setup, find_packages
@@ -6,6 +8,18 @@ from setuptools import setup, find_packages
 tests_require = [
     'Django',
 ]
+
+if sys.argv[-1] == 'publish':
+    if os.system("pip freeze | grep wheel"):
+        print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
+        sys.exit()
+
+    os.system("python setup.py sdist upload")
+    os.system("python setup.py bdist_wheel upload")
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %s -m 'version %s'" % (crispy_forms.__version__, crispy_forms.__version__))
+    print("  git push --tags")
+    sys.exit()
 
 setup(
     name='django-crispy-forms',
@@ -22,6 +36,7 @@ setup(
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,11 @@ if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):
         print("wheel not installed.\nUse `pip install wheel`.\nExiting.")
         sys.exit()
-
-    os.system("python setup.py sdist upload")
-    os.system("python setup.py bdist_wheel upload")
+    if os.system("pip freeze | grep twine"):
+        print("twine not installed.\nUse `pip install twine`.\nExiting.")
+        sys.exit()
+    os.system("python setup.py sdist bdist_wheel")
+    os.system("twine upload dist/*")
     print("You probably want to also tag the version now:")
     print("  git tag -a %s -m 'version %s'" % (crispy_forms.__version__, crispy_forms.__version__))
     print("  git push --tags")


### PR DESCRIPTION
Fixes #459

* Make sure we've got wheel installed. 
* Wrap upload in `publish` command a la @tomchristie's template.