### PR TITLE
Add marks to skip, fix repeated tests execution. #465

### DIFF
--- a/crispy_forms/tests/base.py
+++ b/crispy_forms/tests/base.py
@@ -17,6 +17,7 @@ template_loaders = ['django.template.loaders.filesystem.Loader'] + list(settings
 
 
 class CrispyTestCase(TestCase):
+
     def setUp(self):
         # ensuring test templates directory is loaded first
         self.__overriden_settings = override_settings(**{
@@ -38,3 +39,7 @@ class CrispyTestCase(TestCase):
     @property
     def current_template_pack(self):
         return getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
+
+
+class CustomUrlsTestCase(CrispyTestCase):
+    urls = 'crispy_forms.tests.urls'

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+from django.conf import settings
+
+import pytest
+
+
+def get_skip_mark(*template_packs):
+    return pytest.mark.skipif(settings.CRISPY_TEMPLATE_PACK not in template_packs,
+                              reason='Requires %s template pack' % ' or '.join(template_packs))
+
+
+only_uni_form = get_skip_mark('uni_form')
+only_bootstrap = get_skip_mark('bootstrap', 'bootstrap3')
+only_bootstrap3 = get_skip_mark('bootstrap3')

--- a/crispy_forms/tests/runtests.py
+++ b/crispy_forms/tests/runtests.py
@@ -5,34 +5,8 @@ import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'crispy_forms.tests.test_settings'
 
-base_tests = (
-    'TestBasicFunctionalityTags',
-    'TestFormHelper',
-    'TestFormLayout',
-    'TestLayoutObjects',
-    'TestDynamicLayouts',
-)
-bootstrap_tests = base_tests + (
-    'TestBootstrapFormHelper',
-    'TestBootstrapFormLayout',
-    'TestBootstrapLayoutObjects',
-)
-bootstrap_3_tests = bootstrap_tests + (
-    'TestBootstrap3FormHelper',
-    'TestBootstrap3FormLayout',
-)
-uni_form_tests = base_tests + (
-    'TestUniformFormHelper',
-    'TestUniformFormLayout',
-    'TestUniformDynamicLayouts',
-)
 
-
-for template_pack, tests in (
-        ('uni_form', uni_form_tests),
-        ('bootstrap', bootstrap_tests),
-        ('bootstrap3', bootstrap_3_tests)
-):
-    retval = os.system('CRISPY_TEMPLATE_PACK=%s py.test -k "%s"' % (template_pack, ' or '.join(tests)))
+for template_pack in ('uni_form', 'bootstrap', 'bootstrap3'):
+    retval = os.system('CRISPY_TEMPLATE_PACK=%s py.test' % template_pack)
     if retval:
         sys.exit(1)

--- a/crispy_forms/tests/test_dynamic_api.py
+++ b/crispy_forms/tests/test_dynamic_api.py
@@ -1,22 +1,21 @@
 # -*- coding: utf-8 -*-
-import warnings
 from django import forms
-from django.conf import settings
 from .base import CrispyTestCase
+from .conftest import only_uni_form
 from crispy_forms.compatibility import string_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
-from crispy_forms.layout import Submit
 from crispy_forms.layout import (
-    Layout, Fieldset, MultiField, HTML, Div, Field
+    Submit, Layout, Fieldset, MultiField, HTML, Div, Field
 )
 from crispy_forms.bootstrap import AppendedText
 from crispy_forms.tests.forms import TestForm
 
 
-class TestDynamicLayouts(CrispyTestCase):
+class AdvancedLayoutTestCase(CrispyTestCase):
+
     def setUp(self):
-        super(TestDynamicLayouts, self).setUp()
+        super(AdvancedLayoutTestCase, self).setUp()
 
         self.advanced_layout = Layout(
             Div(
@@ -34,6 +33,9 @@ class TestDynamicLayouts(CrispyTestCase):
             ),
             'last_name',
         )
+
+
+class TestDynamicLayouts(AdvancedLayoutTestCase):
 
     def test_wrap_all_fields(self):
         helper = FormHelper()
@@ -507,11 +509,10 @@ class TestDynamicLayouts(CrispyTestCase):
         self.assertEqual(layout[0][0], 'password1')
 
 
-class TestUniformDynamicLayouts(TestDynamicLayouts):
+@only_uni_form
+class TestUniformDynamicLayouts(AdvancedLayoutTestCase):
+
     def test_filter(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'uni_form':
-            warnings.warn('skipping uniform tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         helper = FormHelper()
         helper.layout = Layout(
             Div(

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 
-import django, warnings
+import django
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -20,7 +20,8 @@ except ImportError:
 
 from django.utils.translation import ugettext_lazy as _
 
-from .base import CrispyTestCase
+from .base import CustomUrlsTestCase
+from .conftest import only_uni_form, only_bootstrap3, only_bootstrap
 from .forms import TestForm
 from crispy_forms.bootstrap import (
     FieldWithButtons, PrependedAppendedText, AppendedText, PrependedText,
@@ -35,8 +36,7 @@ from crispy_forms.utils import render_crispy_form
 from crispy_forms.templatetags.crispy_forms_tags import CrispyFormNode
 
 
-class TestFormHelper(CrispyTestCase):
-    urls = 'crispy_forms.tests.urls'
+class TestFormHelper(CustomUrlsTestCase):
 
     def test_inputs(self):
         form_helper = FormHelper()
@@ -408,11 +408,10 @@ class TestFormHelper(CrispyTestCase):
         self.assertEqual(html.count("<h1>Special custom field</h1>"), 2)
 
 
-class TestUniformFormHelper(TestFormHelper):
+@only_uni_form
+class TestUniformFormHelper(CustomUrlsTestCase):
+
     def test_form_show_errors(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'uni_form':
-            warnings.warn('skipping uniform tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form = TestForm({
             'email': 'invalidemail',
             'first_name': 'first_name_too_long',
@@ -439,9 +438,6 @@ class TestUniformFormHelper(TestFormHelper):
         self.assertEqual(html.count('error'), 0)
 
     def test_multifield_errors(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'uni_form':
-            warnings.warn('skipping uniform tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form = TestForm({
             'email': 'invalidemail',
             'password1': 'yes',
@@ -466,7 +462,9 @@ class TestUniformFormHelper(TestFormHelper):
         self.assertEqual(html.count('error'), 0)
 
 
-class TestBootstrapFormHelper(TestFormHelper):
+@only_bootstrap
+class TestBootstrapFormHelper(CustomUrlsTestCase):
+
     def test_form_show_errors(self):
         form = TestForm({
                 'email': 'invalidemail',
@@ -580,11 +578,10 @@ class TestBootstrapFormHelper(TestFormHelper):
         self.assertEqual(html.count("<label"), 0)
 
 
-class TestBootstrap3FormHelper(TestFormHelper):
+@only_bootstrap3
+class TestBootstrap3FormHelper(CustomUrlsTestCase):
+
     def test_label_class_and_field_class(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'bootstrap3':
-            warnings.warn('skipping bootstrap3 tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form = TestForm()
         form.helper = FormHelper()
         form.helper.label_class = 'col-lg-2'
@@ -602,9 +599,6 @@ class TestBootstrap3FormHelper(TestFormHelper):
         self.assertEqual(html.count('col-sm-8'), 7)
 
     def test_template_pack(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'bootstrap3':
-            warnings.warn('skipping bootstrap3 tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form = TestForm()
         form.helper = FormHelper()
         form.helper.template_pack = 'uni_form'

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import django, warnings
+import django
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -24,7 +24,8 @@ try:
 except ImportError:
     from django.test.utils import override_settings
 
-from .base import CrispyTestCase
+from .base import CustomUrlsTestCase
+from .conftest import only_uni_form, only_bootstrap3, only_bootstrap
 from .forms import (
     TestForm, TestForm2, TestForm3, CheckboxesTestForm,
     TestForm4, CrispyTestModel, TestForm5
@@ -38,8 +39,8 @@ from crispy_forms.layout import (
 )
 from crispy_forms.utils import render_crispy_form
 
-class TestFormLayout(CrispyTestCase):
-    urls = 'crispy_forms.tests.urls'
+
+class TestFormLayout(CustomUrlsTestCase):
 
     def test_invalid_unicode_characters(self):
         # Adds a BooleanField that uses non valid unicode characters "ñ"
@@ -430,12 +431,10 @@ class TestFormLayout(CrispyTestCase):
         self.assertTrue('<span>first span</span> <span>second span</span>' in html)
 
 
-class TestUniformFormLayout(TestFormLayout):
+@only_uni_form
+class TestUniformFormLayout(CustomUrlsTestCase):
 
     def test_layout_composition(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'uni_form':
-            warnings.warn('skipping uniform tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form_helper = FormHelper()
         form_helper.add_layout(
             Layout(
@@ -484,9 +483,6 @@ class TestUniformFormLayout(TestFormLayout):
         self.assertFalse('last_name' in html)
 
     def test_second_layout_multifield_column_buttonholder_submit_div(self):
-        if settings.CRISPY_TEMPLATE_PACK != 'uni_form':
-            warnings.warn('skipping uniform tests with CRISPY_TEMPLATE_PACK=%s' % settings.CRISPY_TEMPLATE_PACK)
-            return
         form_helper = FormHelper()
         form_helper.add_layout(
             Layout(
@@ -545,7 +541,8 @@ class TestUniformFormLayout(TestFormLayout):
         self.assertTrue('test-markup="123"' in html)
 
 
-class TestBootstrapFormLayout(TestFormLayout):
+@only_bootstrap
+class TestBootstrapFormLayout(CustomUrlsTestCase):
 
     def test_keepcontext_context_manager(self):
         # Test case for issue #180
@@ -570,7 +567,8 @@ class TestBootstrapFormLayout(TestFormLayout):
             self.assertEqual(response.content.count(b'checkbox-inline'), 3)
 
 
-class TestBootstrap3FormLayout(TestFormLayout):
+@only_bootstrap3
+class TestBootstrap3FormLayout(CustomUrlsTestCase):
 
     def test_form_inline(self):
         form = TestForm()

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import activate, deactivate
 
 from .base import CrispyTestCase
+from .conftest import only_bootstrap
 from .forms import CheckboxesTestForm, TestForm
 from crispy_forms.bootstrap import (
     PrependedAppendedText, AppendedText, PrependedText, InlineRadios,
@@ -123,7 +124,8 @@ class TestLayoutObjects(CrispyTestCase):
         deactivate()
 
 
-class TestBootstrapLayoutObjects(TestLayoutObjects):
+@only_bootstrap
+class TestBootstrapLayoutObjects(CrispyTestCase):
 
     def test_custom_django_widget(self):
         class CustomRadioSelect(forms.RadioSelect):

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -17,8 +17,8 @@ from .forms import TestForm
 from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 
-
 class TestBasicFunctionalityTags(CrispyTestCase):
+
     def test_as_crispy_errors_form_without_non_field_errors(self):
         template = get_template_from_string(u"""
             {% load crispy_forms_tags %}


### PR DESCRIPTION
Fixes #465 

Here we have globally set CRISPY_TEMPLATE_PACK settings in each run. Before we have to select some tests for each template pack.
Now ```pytest.mark.skipif``` checks for CRISPY_TEMPLATE_PACK setting before test execution. It works for separate test functions and for whole classes as well.
E.g. test class decorated with ```@only_uni_form``` will run only if tests were run with ```CRISPY_TEMPLATE_PACK='uni_form'``` setting otherwise whole class will be skipped to run.
[Here](https://pytest.org/latest/skipping.html#skipping) is doc for test skipping.
I've transformed conditions from https://github.com/maraujop/django-crispy-forms/blob/dev/crispy_forms/tests/runtests.py to marks required test classes. Also base classes were refactored to eliminate repeated tests executions (#465).