### PR TITLE
Сonvert test_tags.py module to py.test style

### DIFF
--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -3,6 +3,8 @@ from django.conf import settings
 
 import pytest
 
+from .base import template_dirs, template_loaders
+
 
 def get_skip_mark(*template_packs):
     return pytest.mark.skipif(settings.CRISPY_TEMPLATE_PACK not in template_packs,
@@ -12,3 +14,9 @@ def get_skip_mark(*template_packs):
 only_uni_form = get_skip_mark('uni_form')
 only_bootstrap = get_skip_mark('bootstrap', 'bootstrap3')
 only_bootstrap3 = get_skip_mark('bootstrap3')
+
+
+@pytest.fixture
+def setup_templates(settings):
+    settings.TEMPLATE_LOADERS = template_loaders
+    settings.TEMPLATE_DIRS = template_dirs

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -3,8 +3,6 @@ from django.conf import settings
 
 import pytest
 
-from .base import template_dirs, template_loaders
-
 
 def get_skip_mark(*template_packs):
     return pytest.mark.skipif(settings.CRISPY_TEMPLATE_PACK not in template_packs,
@@ -14,9 +12,3 @@ def get_skip_mark(*template_packs):
 only_uni_form = get_skip_mark('uni_form')
 only_bootstrap = get_skip_mark('bootstrap', 'bootstrap3')
 only_bootstrap3 = get_skip_mark('bootstrap3')
-
-
-@pytest.fixture
-def setup_templates(settings):
-    settings.TEMPLATE_LOADERS = template_loaders
-    settings.TEMPLATE_DIRS = template_dirs

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.conf import settings
 from django.forms.forms import BoundField
 from django.forms.models import formset_factory
 from django.template import Context
@@ -94,7 +93,7 @@ def test_classes_filter():
     assert 'email-fields' in html
 
 
-def test_crispy_field_and_class_converters():
+def test_crispy_field_and_class_converters(settings):
     if hasattr(settings, 'CRISPY_CLASS_CONVERTERS'):
         template = get_template_from_string(u"""
             {% load crispy_forms_field %}

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -17,9 +17,6 @@ from .forms import TestForm
 from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 
-pytestmark = pytest.mark.usefixtures('setup_templates')
-
-
 def test_as_crispy_errors_form_without_non_field_errors():
     template = get_template_from_string(u"""
         {% load crispy_forms_tags %}

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -4,6 +4,8 @@ from django.forms.forms import BoundField
 from django.forms.models import formset_factory
 from django.template import Context
 
+import pytest
+
 try:
     from django.template.loader import get_template_from_string
 except ImportError:
@@ -12,116 +14,122 @@ except ImportError:
     get_template_from_string = Engine().from_string
 
 
-from .base import CrispyTestCase
 from .forms import TestForm
 from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 
-class TestBasicFunctionalityTags(CrispyTestCase):
+pytestmark = pytest.mark.usefixtures('setup_templates')
 
-    def test_as_crispy_errors_form_without_non_field_errors(self):
-        template = get_template_from_string(u"""
-            {% load crispy_forms_tags %}
-            {{ form|as_crispy_errors }}
-        """)
-        form = TestForm({'password1': "god", 'password2': "god"})
-        form.is_valid()
 
-        c = Context({'form': form})
-        html = template.render(c)
-        self.assertFalse("errorMsg" in html or "alert" in html)
+def test_as_crispy_errors_form_without_non_field_errors():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_tags %}
+        {{ form|as_crispy_errors }}
+    """)
+    form = TestForm({'password1': "god", 'password2': "god"})
+    form.is_valid()
 
-    def test_as_crispy_errors_form_with_non_field_errors(self):
-        template = get_template_from_string(u"""
-            {% load crispy_forms_tags %}
-            {{ form|as_crispy_errors }}
-        """)
-        form = TestForm({'password1': "god", 'password2': "wargame"})
-        form.is_valid()
+    c = Context({'form': form})
+    html = template.render(c)
+    assert not ("errorMsg" in html or "alert" in html)
 
-        c = Context({'form': form})
-        html = template.render(c)
-        self.assertTrue("errorMsg" in html or "alert" in html)
-        self.assertTrue("<li>Passwords dont match</li>" in html)
-        self.assertFalse("<h3>" in html)
 
-    def test_crispy_filter_with_form(self):
-        template = get_template_from_string(u"""
-            {% load crispy_forms_tags %}
-            {{ form|crispy }}
-        """)
-        c = Context({'form': TestForm()})
-        html = template.render(c)
+def test_as_crispy_errors_form_with_non_field_errors():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_tags %}
+        {{ form|as_crispy_errors }}
+    """)
+    form = TestForm({'password1': "god", 'password2': "wargame"})
+    form.is_valid()
 
-        self.assertTrue("<td>" not in html)
-        self.assertTrue("id_is_company" in html)
-        self.assertEqual(html.count('<label'), 7)
+    c = Context({'form': form})
+    html = template.render(c)
+    assert "errorMsg" in html or "alert" in html
+    assert "<li>Passwords dont match</li>" in html
+    assert "<h3>" not in html
 
-    def test_crispy_filter_with_formset(self):
-        template = get_template_from_string(u"""
-            {% load crispy_forms_tags %}
-            {{ testFormset|crispy }}
-        """)
 
-        TestFormset = formset_factory(TestForm, extra=4)
-        testFormset = TestFormset()
+def test_crispy_filter_with_form():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_tags %}
+        {{ form|crispy }}
+    """)
+    c = Context({'form': TestForm()})
+    html = template.render(c)
 
-        c = Context({'testFormset': testFormset})
-        html = template.render(c)
+    assert "<td>" not in html
+    assert "id_is_company" in html
+    assert html.count('<label') == 7
 
-        self.assertEqual(html.count('<form'), 0)
-        # Check formset management form
-        self.assertTrue('form-TOTAL_FORMS' in html)
-        self.assertTrue('form-INITIAL_FORMS' in html)
-        self.assertTrue('form-MAX_NUM_FORMS' in html)
 
-    def test_classes_filter(self):
+def test_crispy_filter_with_formset():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_tags %}
+        {{ testFormset|crispy }}
+    """)
+
+    TestFormset = formset_factory(TestForm, extra=4)
+    testFormset = TestFormset()
+
+    c = Context({'testFormset': testFormset})
+    html = template.render(c)
+
+    assert html.count('<form') == 0
+    # Check formset management form
+    assert 'form-TOTAL_FORMS' in html
+    assert 'form-INITIAL_FORMS' in html
+    assert 'form-MAX_NUM_FORMS' in html
+
+
+def test_classes_filter():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_field %}
+        {{ testField|classes }}
+    """)
+
+    test_form = TestForm()
+    test_form.fields['email'].widget.attrs.update({'class': 'email-fields'})
+    c = Context({'testField': test_form.fields['email']})
+    html = template.render(c)
+    assert 'email-fields' in html
+
+
+def test_crispy_field_and_class_converters():
+    if hasattr(settings, 'CRISPY_CLASS_CONVERTERS'):
         template = get_template_from_string(u"""
             {% load crispy_forms_field %}
-            {{ testField|classes }}
+            {% crispy_field testField 'class' 'error' %}
         """)
-
-        test_form = TestForm()
-        test_form.fields['email'].widget.attrs.update({'class': 'email-fields'})
-        c = Context({'testField': test_form.fields['email']})
-        html = template.render(c)
-        self.assertTrue('email-fields' in html)
-
-    def test_crispy_field_and_class_converters(self):
-        if hasattr(settings, 'CRISPY_CLASS_CONVERTERS'):
-            template = get_template_from_string(u"""
-                {% load crispy_forms_field %}
-                {% crispy_field testField 'class' 'error' %}
-            """)
-            test_form = TestForm()
-            field_instance = test_form.fields['email']
-            bound_field = BoundField(test_form, field_instance, 'email')
-
-            c = Context({'testField': bound_field})
-            html = template.render(c)
-            self.assertTrue('error' in html)
-            self.assertTrue('inputtext' in html)
-
-    def test_crispy_addon(self):
         test_form = TestForm()
         field_instance = test_form.fields['email']
         bound_field = BoundField(test_form, field_instance, 'email')
 
-        if self.current_template_pack == 'bootstrap':
-            # prepend tests
-            self.assertIn("input-prepend", crispy_addon(bound_field, prepend="Work"))
-            self.assertNotIn("input-append", crispy_addon(bound_field, prepend="Work"))
-            # append tests
-            self.assertNotIn("input-prepend", crispy_addon(bound_field, append="Primary"))
-            self.assertIn("input-append", crispy_addon(bound_field, append="Secondary"))
-            # prepend and append tests
-            self.assertIn("input-append", crispy_addon(bound_field, prepend="Work", append="Primary"))
-            self.assertIn("input-prepend", crispy_addon(bound_field, prepend="Work", append="Secondary"))
-        elif self.current_template_pack == 'bootsrap3':
-            self.assertIn("input-group-addon", crispy_addon(bound_field, prepend="Work", append="Primary"))
-            self.assertIn("input-group-addon", crispy_addon(bound_field, prepend="Work", append="Secondary"))
+        c = Context({'testField': bound_field})
+        html = template.render(c)
+        assert 'error' in html
+        assert 'inputtext' in html
 
-        # errors
-        with self.assertRaises(TypeError):
-            crispy_addon()
-            crispy_addon(bound_field)
+
+def test_crispy_addon(settings):
+    test_form = TestForm()
+    field_instance = test_form.fields['email']
+    bound_field = BoundField(test_form, field_instance, 'email')
+
+    if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
+        # prepend tests
+        assert "input-prepend" in crispy_addon(bound_field, prepend="Work")
+        assert "input-append" not in crispy_addon(bound_field, prepend="Work")
+        # append tests
+        assert "input-prepend" not in crispy_addon(bound_field, append="Primary")
+        assert "input-append" in crispy_addon(bound_field, append="Secondary")
+        # prepend and append tests
+        assert "input-append" in crispy_addon(bound_field, prepend="Work", append="Primary")
+        assert "input-prepend" in crispy_addon(bound_field, prepend="Work", append="Secondary")
+    elif settings.CRISPY_TEMPLATE_PACK == 'bootsrap3':
+        assert "input-group-addon" in crispy_addon(bound_field, prepend="Work", append="Primary")
+        assert "input-group-addon" in crispy_addon(bound_field, prepend="Work", append="Secondary")
+
+    # errors
+    with pytest.raises(TypeError):
+        crispy_addon()
+        crispy_addon(bound_field)


### PR DESCRIPTION
Also basic fixture for template-related settings setup added. It has same functionality like [CrispyTestCase](https://github.com/maraujop/django-crispy-forms/blob/dev/crispy_forms/tests/base.py#L19)

Main changes are:
* asserts converted from TestCase's to standard python
* test classes are removed
* current_template_pack is replaced with settings.CRISPY_TEMPLATE_PACK
* the rest of the code is just indented left