### PR TITLE
Remove shims for Django < 1.4

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_utils.py
+++ b/crispy_forms/templatetags/crispy_forms_utils.py
@@ -3,10 +3,7 @@ import re
 
 from django import template
 from django.conf import settings
-try:  # Django < 1.4
-    from django.utils.encoding import force_unicode as force_text
-except ImportError:
-    from django.utils.encoding import force_text
+from django.utils.encoding import force_text
 from django.utils.functional import allow_lazy
 
 from crispy_forms.compatibility import text_type

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -275,10 +275,7 @@ class TestFormHelper(CustomUrlsTestCase):
         c = Context({'form': TestForm(), 'form_helper': "invalid"})
 
         settings.CRISPY_FAIL_SILENTLY = False
-        # Django >= 1.4 is not wrapping exceptions in TEMPLATE_DEBUG mode
-        if settings.TEMPLATE_DEBUG and django.VERSION < (1, 4):
-            self.assertRaises(TemplateSyntaxError, lambda:template.render(c))
-        else:
+        if not settings.TEMPLATE_DEBUG:
             self.assertRaises(TypeError, lambda:template.render(c))
         del settings.CRISPY_FAIL_SILENTLY
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -278,7 +278,7 @@ class TestFormLayout(CustomUrlsTestCase):
             self.assertEqual(html.count(
                 'type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS"'
             ), 1)
-            if (django_version >= (1, 4) and django_version < (1, 4, 4)) or django_version < (1, 3, 6):
+            if (1, 4) <= django_version < (1, 4, 4):
                 self.assertEqual(html.count(
                     'type="hidden" name="form-MAX_NUM_FORMS" id="id_form-MAX_NUM_FORMS"'
                 ), 1)


### PR DESCRIPTION
Now, when Django < 1.4 is not supported, this code is not required.