### PR TITLE
Fix style issues and add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{html,py,rst}]
+indent_style = space
+indent_size = 4
+
+[*.{html,rst}]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+insert_final_newline = false

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -41,8 +41,8 @@ class LayoutObject(object):
         is the location of the field, second one the name of the field. Example::
 
             [
-               [[0,1,2], 'field_name1'],
-               [[0,3], 'field_name2']
+                [[0,1,2], 'field_name1'],
+                [[0,3], 'field_name2']
             ]
         """
         return self.get_layout_objects(string_types, greedy=True)
@@ -53,8 +53,8 @@ class LayoutObject(object):
         `LayoutClasses`::
 
             [
-               [[0,1,2], 'div'],
-               [[0,3], 'field_name']
+                [[0,1,2], 'div'],
+                [[0,3], 'field_name']
             ]
 
         :param max_level: An integer that indicates max level depth to reach when

--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -1,14 +1,14 @@
 {% load crispy_forms_field %}
 
 {% if field.is_hidden %}
-	{{ field }}
+    {{ field }}
 {% else %}
-	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="control-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-		{% if field.label and not field|is_checkbox and form_show_labels %}
-			<label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-			</label>
-		{% endif %}
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="control-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+        {% if field.label and not field|is_checkbox and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
 
         {% if field|is_checkboxselectmultiple %}
             {% include 'bootstrap/layout/checkboxselectmultiple.html' %}
@@ -32,5 +32,5 @@
                 {% endif %}
             </div>
         {% endif %}
-	</{% if tag %}{{ tag }}{% else %}div{% endif %}>
+    </{% if tag %}{{ tag }}{% else %}div{% endif %}>
 {% endif %}

--- a/crispy_forms/templates/bootstrap/layout/alert.html
+++ b/crispy_forms/templates/bootstrap/layout/alert.html
@@ -1,4 +1,4 @@
 <div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
-  {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-  {{ content|safe }}
+    {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
+    {{ content|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap/layout/div.html
+++ b/crispy_forms/templates/bootstrap/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
-       {{ fields|safe }}
+        {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap/table_inline_formset.html
@@ -16,18 +16,18 @@
 
     <table{% if form_id %} id="{{ form_id }}_table"{% endif%} class="table table-striped table-condensed">
         <thead>
-          {% if formset.readonly and not formset.queryset.exists %}
-          {% else %}
-              <tr>
-                  {% for field in formset.forms.0 %}
-                      {% if field.label and not field.is_hidden %}
-                          <th for="{{ field.auto_id }}" class="control-label {% if field.field.required and not field|is_checkbox %}requiredField{% endif %}">
-                              {{ field.label|safe }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
-                          </th>
-                      {% endif %}
-                  {% endfor %}
-              </tr>
-          {% endif %}
+            {% if formset.readonly and not formset.queryset.exists %}
+            {% else %}
+                <tr>
+                    {% for field in formset.forms.0 %}
+                        {% if field.label and not field.is_hidden %}
+                            <th for="{{ field.auto_id }}" class="control-label {% if field.field.required and not field|is_checkbox %}requiredField{% endif %}">
+                                {{ field.label|safe }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
+                            </th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endif %}
         </thead>
 
         <tbody>

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_field %}
 
 {% if field.is_hidden %}
-	{{ field }}
+    {{ field }}
 {% else %}
     {% if field|is_checkbox %}
         <div class="form-group">
@@ -9,12 +9,12 @@
             <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
         {% endif %}
     {% endif %}
-	<{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-		{% if field.label and not field|is_checkbox and form_show_labels %}
-			<label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-			</label>
-		{% endif %}
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+        {% if field.label and not field|is_checkbox and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
 
         {% if field|is_checkboxselectmultiple %}
             {% include 'bootstrap3/layout/checkboxselectmultiple.html' %}
@@ -38,7 +38,7 @@
                 </div>
             {% endif %}
         {% endif %}
-	</{% if tag %}{{ tag }}{% else %}div{% endif %}>
+    </{% if tag %}{{ tag }}{% else %}div{% endif %}>
     {% if field|is_checkbox %}
         {% if label_class %}
             </div>

--- a/crispy_forms/templates/bootstrap3/layout/alert.html
+++ b/crispy_forms/templates/bootstrap3/layout/alert.html
@@ -1,4 +1,4 @@
 <div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
-  {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-  {{ content|safe }}
+    {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
+    {{ content|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/div.html
+++ b/crispy_forms/templates/bootstrap3/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
-       {{ fields|safe }}
+        {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap3/layout/formactions.html
@@ -1,9 +1,9 @@
 <div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group">
-   {% if label_class %}
-       <div class="aab controls {{ label_class }}"></div>
-   {% endif %}
+    {% if label_class %}
+        <div class="aab controls {{ label_class }}"></div>
+    {% endif %}
 
-   <div class="controls {{ field_class }}">
-    {{ fields_output|safe }}
-   </div>
+    <div class="controls {{ field_class }}">
+        {{ fields_output|safe }}
+    </div>
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/inline_field.html
+++ b/crispy_forms/templates/bootstrap3/layout/inline_field.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_field %}
 
 {% if field.is_hidden %}
-	{{ field }}
+    {{ field }}
 {% else %}
     {% if field|is_checkbox %}
         <div id="div_{{ field.auto_id }}" class="checkbox">

--- a/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
@@ -12,16 +12,16 @@
         {% endif %}
 
         <div class="controls {{ field_class }}">
-          {% if field|is_select %}
-            {% if crispy_prepended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
-            {% crispy_field field %}
-            {% if crispy_appended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
-          {% else %}
-            <div class="input-group">
-                {% if crispy_prepended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
+            {% if field|is_select %}
+                {% if crispy_prepended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
                 {% crispy_field field %}
-                {% if crispy_appended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
-            </div>
+                {% if crispy_appended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+            {% else %}
+                <div class="input-group">
+                    {% if crispy_prepended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
+                    {% crispy_field field %}
+                    {% if crispy_appended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+                </div>
           {% endif %}
 
             {% include 'bootstrap3/layout/help_text_and_errors.html' %}

--- a/crispy_forms/templates/bootstrap3/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap3/table_inline_formset.html
@@ -16,18 +16,18 @@
 
     <table{% if form_id %} id="{{ form_id }}_table"{% endif%} class="table table-striped table-condensed">
         <thead>
-          {% if formset.readonly and not formset.queryset.exists %}
-          {% else %}
-              <tr>
-                  {% for field in formset.forms.0 %}
-                      {% if field.label and not field|is_checkbox and not field.is_hidden %}
-                          <th for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-                              {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-                          </th>
-                      {% endif %}
-                  {% endfor %}
-              </tr>
-          {% endif %}
+            {% if formset.readonly and not formset.queryset.exists %}
+            {% else %}
+                <tr>
+                    {% for field in formset.forms.0 %}
+                        {% if field.label and not field|is_checkbox and not field.is_hidden %}
+                            <th for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
+                                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                            </th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endif %}
         </thead>
 
         <tbody>

--- a/crispy_forms/templates/uni_form/layout/div.html
+++ b/crispy_forms/templates/uni_form/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
-       {{ fields|safe }}
+        {{ fields|safe }}
 </div>

--- a/docs/dynamic_layouts.rst
+++ b/docs/dynamic_layouts.rst
@@ -35,9 +35,9 @@ wrap
 One useful action you can apply on a slice is ``wrap``, which wraps every selected field using a layout object type and parameters passed. Let's see an example. If We had this layout::
 
     Layout(
-       'field_1',
-       'field_2',
-       'field_3'
+        'field_1',
+        'field_2',
+        'field_3'
     )
 
 We could do::


### PR DESCRIPTION
Changes:
- Fix indentation issues
- Add EditorConfig file with rules for HTML, Python, reStructuredText, and Makefile

Besides adding the `.editorconfig` file, these changes only fix indentation.  [See this diff that ignores whitespace changes][whitespace].

I noticed the need for `.editorconfig` when editing the Makefile because my editor wanted to add a final newline which would make unnecessary git noise.

**Disclosure**: I am one of the creators of the EditorConfig project

(replaces #488)

[whitespace]: https://github.com/maraujop/django-crispy-forms/pull/490/files?w=1