### PR TITLE
Allow LayoutObject & BaseInputs to accept custom template

### DIFF
--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
 from django import forms
 from django.template import Context
 

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from django import forms
 from django.template import Context
 
@@ -25,6 +26,20 @@ from crispy_forms.layout import (
 )
 from crispy_forms.utils import render_crispy_form
 
+def test_field_with_custom_template():
+    template = get_template_from_string(u"""
+        {% load crispy_forms_tags %}
+        {% crispy form %}
+    """)
+
+    test_form = TestForm()
+    test_form.helper = FormHelper()
+    test_form.helper.layout = Layout(
+        Field('email',template='custom_field_template.html')
+    )
+
+    html = render_crispy_form(test_form)
+    assert '<h1>Special custom field</h1>' in html
 
 def test_multiwidget_field():
     template = get_template_from_string(u"""


### PR DESCRIPTION
Fixes #448, fixes #361

Introduce `get_template_name` method to apply conditional template name resolution. (via @marshalc in [comment here](https://github.com/maraujop/django-crispy-forms/issues/361#issuecomment-128499014))

Apply to both LayoutObject and BaseInput hierarchies. 