### PR TITLE
Exclude Python 3.2 and 3.3 from Travis & tox builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,12 @@ matrix:
   exclude:
     - python: "3.2"
       env: DJANGO='django>=1.4.0,<1.5.0'
+    - python: "3.2"
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.3"
       env: DJANGO='django>=1.4.0,<1.5.0'
+    - python: "3.3"
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.4"
       env: DJANGO='django>=1.4.0,<1.5.0'
     - python: "2.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py26-django14,
-    {py27,py33,py34}-{django17,django18,django-latest}
+    py26-django14
+    {py27,py32,py33,py34}-{django17,django18}
+    {py27,py34}-django-latest
 
 [testenv]
 deps =


### PR DESCRIPTION
According to [Django doc](https://docs.djangoproject.com/en/dev/releases/1.9/#python-compatibility), starting from version 1.9 support for Python 3.2 and 3.3 will be dropped.
Also, I've added proper Python 3.2 builds to tox.ini.