### PR TITLE
Add support for HTML5 Form target attribute

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -137,6 +137,8 @@ class FormHelper(DynamicLayoutHandler):
 
         **form_tag**: It specifies if <form></form> tags should be rendered when using a Layout.
             If set to False it renders the form without the <form></form> tags. Defaults to True.
+            
+        **form_target**: Specifies a target for the response returning from the submission of the form.
 
         **form_error_title**: If a form has `non_field_errors` to display, they
             are rendered in a div. You can set title's div with this attribute.
@@ -188,6 +190,7 @@ class FormHelper(DynamicLayoutHandler):
     form_class = ''
     layout = None
     form_tag = True
+    form_target = '_self'
     form_error_title = None
     formset_error_title = None
     form_show_errors = True
@@ -360,6 +363,8 @@ class FormHelper(DynamicLayoutHandler):
             items['attrs']['action'] = self.form_action.strip()
         if self.form_id:
             items['attrs']['id'] = self.form_id.strip()
+        if self.form_target != '_self':
+            items['attrs']['target'] = self.form_target
         if self.form_class:
             # uni_form TEMPLATE PACK has a uniForm class by default
             if template_pack == 'uni_form':


### PR DESCRIPTION
Feature Addition: Support of HTML5 Form Target Attribute
https://developer.mozilla.org/en/docs/Web/HTML/Element/form#attr-target

I think this is how supporting this feature would be accomplished. 
I'm hoping that @maraujop will check it over and ensure I've not missed anything. 