### PR TITLE
Pin coverage to 3.7.1 for Python 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django
+coverage==3.7.1
 twine==1.5.0
 wheel==0.24.0
 pytest


### PR DESCRIPTION
v4 does not support Python 3.2