### PR TITLE
Add include_media FormHelper attribute to make form media inclusion optional

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -148,6 +148,9 @@ class FormHelper(DynamicLayoutHandler):
         **form_style**: Uni-form has two built in different form styles. You can choose
             your favorite. This can be set to "default" or "inline". Defaults to "default".
 
+        **include_media**: Whether to automatically include form media. Set to False if
+            you want to manually include form media outside the form. Defaults to True.
+
     Public Methods:
 
         **add_input(input)**: You can add input buttons using this method. Inputs
@@ -203,6 +206,7 @@ class FormHelper(DynamicLayoutHandler):
     disable_csrf = False
     label_class = ''
     field_class = ''
+    include_media = True
 
     def __init__(self, form=None):
         self.attrs = {}
@@ -341,7 +345,8 @@ class FormHelper(DynamicLayoutHandler):
             'form_show_labels': self.form_show_labels,
             'disable_csrf': self.disable_csrf,
             'label_class': self.label_class,
-            'field_class': self.field_class
+            'field_class': self.field_class,
+            'include_media': self.include_media
         }
         # col-[lg|md|sm|xs]-<number>
         label_size_match = re.search('(\d+)', self.label_class)

--- a/crispy_forms/templates/bootstrap/display_form.html
+++ b/crispy_forms/templates/bootstrap/display_form.html
@@ -1,5 +1,5 @@
 {% if form.form_html %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap/uni_form.html
+++ b/crispy_forms/templates/bootstrap/uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap3/display_form.html
+++ b/crispy_forms/templates/bootstrap3/display_form.html
@@ -1,5 +1,5 @@
 {% if form.form_html %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap3/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap3/uni_form.html
+++ b/crispy_forms/templates/bootstrap3/uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap3/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/display_form.html
+++ b/crispy_forms/templates/bootstrap4/display_form.html
@@ -1,5 +1,5 @@
 {% if form.form_html %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap4/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/uni_form.html
+++ b/crispy_forms/templates/bootstrap4/uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "bootstrap4/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/uni_form/display_form.html
+++ b/crispy_forms/templates/uni_form/display_form.html
@@ -1,5 +1,5 @@
 {% if form.form_html %}
-    {{ form.media }}
+    {% if include_media %}{{ form.media }}{% endif %}
     {% if form_show_errors %}
         {% include "uni_form/errors.html" %}
     {% endif %}

--- a/crispy_forms/templates/uni_form/uni_form.html
+++ b/crispy_forms/templates/uni_form/uni_form.html
@@ -1,4 +1,4 @@
-{{ form.media }}
+{% if include_media %}{{ form.media }}{% endif %}
 {% if form_show_errors %}
     {% include "uni_form/errors.html" %}
 {% endif %}

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -184,6 +184,7 @@ class BasicNode(template.Node):
             'label_class': attrs.get('label_class', ''),
             'label_size': attrs.get('label_size', 0),
             'field_class': attrs.get('field_class', ''),
+            'include_media': attrs.get('include_media', True),
         }
 
         # Handles custom attributes added to helpers

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -115,3 +115,9 @@ class TestForm5(forms.Form):
         choices=choices
     )
     pk = forms.IntegerField()
+
+
+class TestFormWithMedia(forms.Form):
+    class Media:
+        css = {'all': ('test.css',)}
+        js = ('test.js',)

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -182,6 +182,15 @@ def test_media_is_included_by_default_with_bootstrap3():
     assert 'test.js' in html
 
 
+def test_media_is_included_by_default_with_bootstrap4():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap4'
+    html = render_crispy_form(form)
+    assert 'test.css' in html
+    assert 'test.js' in html
+
+
 def test_media_removed_when_include_media_is_false_with_uniform():
     form = TestFormWithMedia()
     form.helper = FormHelper()
@@ -206,6 +215,16 @@ def test_media_removed_when_include_media_is_false_with_bootstrap3():
     form = TestFormWithMedia()
     form.helper = FormHelper()
     form.helper.template_pack = 'bootstrap3'
+    form.helper.include_media = False
+    html = render_crispy_form(form)
+    assert 'test.css' not in html
+    assert 'test.js' not in html
+
+
+def test_media_removed_when_include_media_is_false_with_bootstrap4():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap4'
     form.helper.include_media = False
     html = render_crispy_form(form)
     assert 'test.css' not in html

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from .compatibility import get_template_from_string
 from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
-from .forms import TestForm
+from .forms import TestForm, TestFormWithMedia
 from crispy_forms.bootstrap import (
     FieldWithButtons, PrependedAppendedText, AppendedText, PrependedText,
     StrictButton
@@ -153,6 +153,63 @@ def test_html5_required():
     form.helper = FormHelper()
     form.helper.html5_required = False
     html = render_crispy_form(form)
+
+
+def test_media_is_included_by_default_with_uniform():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'uni_form'
+    html = render_crispy_form(form)
+    assert 'test.css' in html
+    assert 'test.js' in html
+
+
+def test_media_is_included_by_default_with_bootstrap():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap'
+    html = render_crispy_form(form)
+    assert 'test.css' in html
+    assert 'test.js' in html
+
+
+def test_media_is_included_by_default_with_bootstrap3():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap3'
+    html = render_crispy_form(form)
+    assert 'test.css' in html
+    assert 'test.js' in html
+
+
+def test_media_removed_when_include_media_is_false_with_uniform():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'uni_form'
+    form.helper.include_media = False
+    html = render_crispy_form(form)
+    assert 'test.css' not in html
+    assert 'test.js' not in html
+
+
+def test_media_removed_when_include_media_is_false_with_bootstrap():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap'
+    form.helper.include_media = False
+    html = render_crispy_form(form)
+    assert 'test.css' not in html
+    assert 'test.js' not in html
+
+
+def test_media_removed_when_include_media_is_false_with_bootstrap3():
+    form = TestFormWithMedia()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap3'
+    form.helper.include_media = False
+    html = render_crispy_form(form)
+    assert 'test.css' not in html
+    assert 'test.js' not in html
 
 
 def test_attrs():

--- a/docs/form_helper.rst
+++ b/docs/form_helper.rst
@@ -93,6 +93,9 @@ Helper attributes you can set
 **render_required_fields = False**
     By default django-crispy-forms renders the layout specified if it exists strictly. Sometimes you might be interested in rendering all form's hidden required fields no matter if they are mentioned or not. It defaults to ``False``.
 
+**include_media = True**
+    By default django-crispy-forms renders all form media for you within the form. If you want to render form media yourself manually outside the form, set this to ``False``. If you want to globally prevent rendering of form media, override the FormHelper class with this setting modified. It defaults to ``False``.
+
 
 Bootstrap Helper attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This adds a FormHelper attribute "include_media", which defaults to True and controls whether form media is included with the form. Having this attribute makes it much easier to use crispy forms in scenarios which require special handling of media, such as with javascript loading systems, with django-compressor (in offline compression mode), and when the media might produce duplicate javascript when more than one form is on a page. Without this setting, crispy templates must be overridden, which is somewhat more cumbersome. The pull request includes code changes, documentation changes, and 6 new tests.