### PR TITLE
Add Bootstrap4 support

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -26,6 +26,11 @@ class PrependedAppendedText(Field):
             self.input_size = 'input-lg'
         if 'input-sm' in css_class:
             self.input_size = 'input-sm'
+        # bootstrap 4
+        if 'form-control-lg' in css_class:
+            self.input_size = 'form-control-lg'
+        if 'form-control-sm' in css_class:
+            self.input_size = 'form-control-sm'
 
         super(PrependedAppendedText, self).__init__(field, *args, **kwargs)
 

--- a/crispy_forms/templates/bootstrap4/accordion-group.html
+++ b/crispy_forms/templates/bootstrap4/accordion-group.html
@@ -1,0 +1,12 @@
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h4 class="panel-title">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#{{ div.data_parent }}" href="#{{ div.css_id }}">{{ div.name }}</a>
+        </h4>
+    </div>
+    <div id="{{ div.css_id }}" class="panel-collapse collapse{% if div.active %} in{% endif %}" >
+        <div class="panel-body">
+            {{ fields|safe }}
+        </div>
+    </div>
+</div>

--- a/crispy_forms/templates/bootstrap4/accordion.html
+++ b/crispy_forms/templates/bootstrap4/accordion.html
@@ -1,0 +1,3 @@
+<div class="panel-group" id="{{ accordion.css_id }}">
+    {{ content|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap4/betterform.html
+++ b/crispy_forms/templates/bootstrap4/betterform.html
@@ -1,0 +1,22 @@
+{% for fieldset in form.fieldsets %}
+    <fieldset class="fieldset-{{ forloop.counter }} {{ fieldset.classes }}">
+        {% if fieldset.legend %}
+            <legend>{{ fieldset.legend }}</legend>
+        {% endif %}
+
+        {% if fieldset.description %}
+            <p class="description">{{ fieldset.description }}</p>
+        {% endif %}
+
+        {% for field in fieldset %}
+            {% if field.is_hidden %}
+                {{ field }}
+            {% else %}
+                {% include "bootstrap4/field.html" %}
+            {% endif %}
+        {% endfor %}
+    {% if not forloop.last or not fieldset_open %}
+        </fieldset>
+    {% endif %}
+{% endfor %}
+

--- a/crispy_forms/templates/bootstrap4/display_form.html
+++ b/crispy_forms/templates/bootstrap4/display_form.html
@@ -1,0 +1,9 @@
+{% if form.form_html %}
+    {{ form.media }}
+    {% if form_show_errors %}
+        {% include "bootstrap4/errors.html" %}
+    {% endif %}
+    {{ form.form_html }}
+{% else %}
+    {% include "bootstrap4/uni_form.html" %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/errors.html
+++ b/crispy_forms/templates/bootstrap4/errors.html
@@ -1,0 +1,8 @@
+{% if form.non_field_errors %}
+    <div class="alert alert-block alert-danger">
+        {% if form_error_title %}<h4 class="alert-heading">{{ form_error_title }}</h4>{% endif %}
+        <ul>
+            {{ form.non_field_errors|unordered_list }}
+        </ul>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/errors_formset.html
+++ b/crispy_forms/templates/bootstrap4/errors_formset.html
@@ -1,0 +1,9 @@
+{% if formset.non_form_errors %}
+    <div class="alert alert-block alert-danger">
+        {% if formset_error_title %}<h4 class="alert-heading">{{ formset_error_title }}</h4>{% endif %}
+        <ul>
+            {{ formset.non_form_errors|unordered_list }}
+        </ul>
+    </div>
+{% endif %}
+

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -4,12 +4,12 @@
     {{ field }}
 {% else %}
     {% if field|is_checkbox %}
-        <div class="form-group">
+        <div class="form-group row">
         {% if label_class %}
             <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
         {% endif %}
     {% endif %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group row{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -1,0 +1,48 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    {% if field|is_checkbox %}
+        <div class="form-group">
+        {% if label_class %}
+            <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
+        {% endif %}
+    {% endif %}
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+        {% if field.label and not field|is_checkbox and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        {% if field|is_checkboxselectmultiple %}
+            {% include 'bootstrap4/layout/checkboxselectmultiple.html' %}
+        {% endif %}
+
+        {% if field|is_radioselect %}
+            {% include 'bootstrap4/layout/radioselect.html' %}
+        {% endif %}
+
+        {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
+            {% if field|is_checkbox and form_show_labels %}
+                <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
+                    {% crispy_field field %}
+                    {{ field.label|safe }}
+                    {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+                </label>
+            {% else %}
+                <div class="controls {{ field_class }}">
+                    {% crispy_field field %}
+                    {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+                </div>
+            {% endif %}
+        {% endif %}
+    </{% if tag %}{{ tag }}{% else %}div{% endif %}>
+    {% if field|is_checkbox %}
+        {% if label_class %}
+            </div>
+        {% endif %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/inputs.html
+++ b/crispy_forms/templates/bootstrap4/inputs.html
@@ -1,5 +1,5 @@
 {% if inputs %}
-    <div class="form-group">
+    <div class="form-group row">
         {% if label_class %}
             <div class="aab controls {{ label_class }}"></div>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/inputs.html
+++ b/crispy_forms/templates/bootstrap4/inputs.html
@@ -1,0 +1,13 @@
+{% if inputs %}
+    <div class="form-group">
+        {% if label_class %}
+            <div class="aab controls {{ label_class }}"></div>
+        {% endif %}
+
+        <div class="controls {{ field_class }}">
+            {% for input in inputs %}
+                {% include "bootstrap4/layout/baseinput.html" %}
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/alert.html
+++ b/crispy_forms/templates/bootstrap4/layout/alert.html
@@ -1,0 +1,4 @@
+<div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
+    {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
+    {{ content|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/baseinput.html
+++ b/crispy_forms/templates/bootstrap4/layout/baseinput.html
@@ -1,0 +1,9 @@
+<input type="{{ input.input_type }}"
+    name="{% if input.name|wordcount > 1 %}{{ input.name|slugify }}{% else %}{{ input.name }}{% endif %}"
+    value="{{ input.value }}"
+    {% if input.input_type != "hidden" %}
+        class="{{ input.field_classes }}"
+        id="{% if input.id %}{{ input.id }}{% else %}{{ input.input_type }}-id-{{ input.name|slugify }}{% endif %}"
+    {% endif %}
+    {{ input.flat_attrs|safe }}
+    />

--- a/crispy_forms/templates/bootstrap4/layout/button.html
+++ b/crispy_forms/templates/bootstrap4/layout/button.html
@@ -1,0 +1,1 @@
+<button {{ button.flat_attrs|safe }}>{{ button.content|safe }}</button>

--- a/crispy_forms/templates/bootstrap4/layout/buttonholder.html
+++ b/crispy_forms/templates/bootstrap4/layout/buttonholder.html
@@ -1,0 +1,4 @@
+<div {% if buttonholder.css_id %}id="{{ buttonholder.css_id }}"{% endif %} 
+    class="buttonHolder{% if buttonholder.css_class %} {{ buttonholder.css_class }}{% endif %}">
+       {{ fields_output|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -1,0 +1,17 @@
+{% load crispy_forms_filters %}
+{% load l10n %}
+
+<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+    {% include 'bootstrap4/layout/field_errors_block.html' %}
+
+    {% for choice in field.field.choices %}
+
+      {% if not inline_class %}<div class="checkbox">{% endif %}
+        <label class="{% if inline_class %}checkbox-{{ inline_class }}{% endif %}">
+            <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        </label>
+      {% if not inline_class %}</div>{% endif %}
+    {% endfor %}
+
+    {% include 'bootstrap4/layout/help_text.html' %}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group row{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,0 +1,14 @@
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+        {% if field.label %}
+            <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        {% include 'bootstrap4/layout/checkboxselectmultiple.html' %}
+    </div>
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/div.html
+++ b/crispy_forms/templates/bootstrap4/layout/div.html
@@ -1,0 +1,4 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/field_errors.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_errors.html
@@ -1,0 +1,5 @@
+{% if form_show_errors and field.errors %}
+    {% for error in field.errors %}
+        <span id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></span>
+    {% endfor %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/field_errors_block.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_errors_block.html
@@ -1,0 +1,5 @@
+{% if form_show_errors and field.errors %}
+    {% for error in field.errors %}
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></p>
+    {% endfor %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,0 +1,17 @@
+{% load crispy_forms_field %}
+
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+    {% if field.label and form_show_labels %}
+        <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+        </label>
+    {% endif %}
+
+    <div class="controls {{ field_class }}">
+        <div class="input-group">
+            {% crispy_field field %}
+            <span class="input-group-btn{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
+        </div>
+        {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+    </div>
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group row{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap4/layout/fieldset.html
@@ -1,0 +1,6 @@
+<fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
+    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {{ fieldset.flat_attrs|safe }}>
+    {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
+    {{ fields|safe }} 
+</fieldset>

--- a/crispy_forms/templates/bootstrap4/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap4/layout/formactions.html
@@ -1,0 +1,9 @@
+<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group">
+    {% if label_class %}
+        <div class="aab controls {{ label_class }}"></div>
+    {% endif %}
+
+    <div class="controls {{ field_class }}">
+        {{ fields_output|safe }}
+    </div>
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap4/layout/formactions.html
@@ -1,4 +1,4 @@
-<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group">
+<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group row">
     {% if label_class %}
         <div class="aab controls {{ label_class }}"></div>
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/help_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/help_text.html
@@ -1,0 +1,7 @@
+{% if field.help_text %}
+    {% if help_text_inline %}
+        <span id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
+    {% else %}
+        <p id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</p>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/help_text_and_errors.html
+++ b/crispy_forms/templates/bootstrap4/layout/help_text_and_errors.html
@@ -1,0 +1,13 @@
+{% if help_text_inline and not error_text_inline %}
+    {% include 'bootstrap4/layout/help_text.html' %}
+{% endif %}
+
+{% if error_text_inline %}
+    {% include 'bootstrap4/layout/field_errors.html' %}
+{% else %}
+    {% include 'bootstrap4/layout/field_errors_block.html' %}
+{% endif %}
+
+{% if not help_text_inline %}
+    {% include 'bootstrap4/layout/help_text.html' %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/inline_field.html
+++ b/crispy_forms/templates/bootstrap4/layout/inline_field.html
@@ -1,0 +1,21 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    {% if field|is_checkbox %}
+        <div id="div_{{ field.auto_id }}" class="checkbox">
+            <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
+                {% crispy_field field 'class' 'checkbox' %}
+                {{ field.label|safe }}
+            </label>
+        </div>
+    {% else %}
+        <div id="div_{{ field.auto_id }}" class="form-group">
+            <label for="{{ field.id_for_label }}" class="sr-only{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}
+            </label>
+            {% crispy_field field 'placeholder' field.label %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap4/layout/multifield.html
@@ -1,0 +1,27 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+
+    {% if field.label %}
+        <label for="{{ field.id_for_label }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
+    {% endif %}
+
+    {% if field|is_checkbox %}
+        {% crispy_field field %}
+    {% endif %}
+
+    {% if field.label %}
+        {{ field.label }}
+    {% endif %}
+
+    {% if not field|is_checkbox %}
+        {% crispy_field field %}
+    {% endif %}
+
+    {% if field.label %}
+        </label>
+    {% endif %}
+
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group row{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -1,0 +1,30 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+        {% if field.label and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        <div class="controls {{ field_class }}">
+            {% if field|is_select %}
+                {% if crispy_prepended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
+                {% crispy_field field %}
+                {% if crispy_appended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+            {% else %}
+                <div class="input-group">
+                    {% if crispy_prepended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
+                    {% crispy_field field %}
+                    {% if crispy_appended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+                </div>
+          {% endif %}
+
+            {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+        </div>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -1,0 +1,16 @@
+{% load crispy_forms_filters %}
+{% load l10n %}
+
+<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+    {% include 'bootstrap4/layout/field_errors_block.html' %}
+
+    {% for choice in field.field.choices %}
+      {% if not inline_class %}<div class="radio">{% endif %}
+        <label class="{% if inline_class %}radio-{{ inline_class }}{% endif %}">
+            <input type="radio"{% if choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        </label>
+      {% if not inline_class %}</div>{% endif %}
+    {% endfor %}
+
+    {% include 'bootstrap4/layout/help_text.html' %}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group row{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -1,0 +1,14 @@
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+        {% if field.label %}
+            <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        {% include 'bootstrap4/layout/radioselect.html' %}
+    </div>
+{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/tab-link.html
+++ b/crispy_forms/templates/bootstrap4/layout/tab-link.html
@@ -1,0 +1,1 @@
+<li class="tab-pane{% if 'active' in link.css_class %} active{% endif %}"><a href="#{{ link.css_id }}" data-toggle="tab">{{ link.name|capfirst }}{% if tab.errors %}!{% endif %}</a></li>

--- a/crispy_forms/templates/bootstrap4/layout/tab.html
+++ b/crispy_forms/templates/bootstrap4/layout/tab.html
@@ -1,0 +1,6 @@
+<ul{% if tabs.css_id %} id="{{ tabs.css_id }}"{% endif %} class="nav nav-tabs">
+    {{ links|safe }}
+</ul>
+<div class="tab-content panel-body">
+    {{ content|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_field %}
 
 
-<div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+<div id="div_{{ field.auto_id }}" class="form-group row{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
     <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
     <div class="controls {{ field_class }}">
         {% crispy_field field 'disabled' 'disabled' %}

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -1,0 +1,10 @@
+{% load crispy_forms_field %}
+
+
+<div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
+    <div class="controls {{ field_class }}">
+        {% crispy_field field 'disabled' 'disabled' %}
+        {% include 'bootstrap4/layout/help_text.html' %}
+    </div>
+</div>

--- a/crispy_forms/templates/bootstrap4/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap4/table_inline_formset.html
@@ -1,0 +1,51 @@
+{% load crispy_forms_tags %}
+{% load crispy_forms_utils %}
+{% load crispy_forms_field %}
+
+{% specialspaceless %}
+{% if formset_tag %}
+<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+{% endif %}
+    {% if formset_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    <div>
+        {{ formset.management_form|crispy }}
+    </div>
+
+    <table{% if form_id %} id="{{ form_id }}_table"{% endif%} class="table table-striped table-sm">
+        <thead>
+            {% if formset.readonly and not formset.queryset.exists %}
+            {% else %}
+                <tr>
+                    {% for field in formset.forms.0 %}
+                        {% if field.label and not field|is_checkbox and not field.is_hidden %}
+                            <th for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
+                                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                            </th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endif %}
+        </thead>
+
+        <tbody>
+            {% for form in formset %}
+                {% if form_show_errors and not form.is_extra %}
+                    {% include "bootstrap4/errors.html" %}
+                {% endif %}
+
+                <tr>
+                    {% for field in form %}
+                        {% include 'bootstrap4/field.html' with tag="th" form_show_labels=False %}
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% include "bootstrap4/inputs.html" %}
+
+{% if formset_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/bootstrap4/uni_form.html
+++ b/crispy_forms/templates/bootstrap4/uni_form.html
@@ -1,0 +1,11 @@
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+    {{ form.media }}
+    {% if form_show_errors %}
+        {% include "bootstrap4/errors.html" %}
+    {% endif %}
+    {% for field in form %}
+        {% include "bootstrap4/field.html" %}
+    {% endfor %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/bootstrap4/uni_formset.html
+++ b/crispy_forms/templates/bootstrap4/uni_formset.html
@@ -1,0 +1,8 @@
+{% with formset.management_form as form %}
+    {% include 'bootstrap4/uni_form.html' %}
+{% endwith %}
+{% for form in formset %}
+    <div class="multiField">
+        {% include 'bootstrap4/uni_form.html' %}
+    </div>
+{% endfor %}

--- a/crispy_forms/templates/bootstrap4/whole_uni_form.html
+++ b/crispy_forms/templates/bootstrap4/whole_uni_form.html
@@ -1,0 +1,14 @@
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+{% if form_tag %}<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
+    {% if form_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    {% include "bootstrap4/display_form.html" %}
+
+    {% include "bootstrap4/inputs.html" %}
+
+{% if form_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/bootstrap4/whole_uni_formset.html
+++ b/crispy_forms/templates/bootstrap4/whole_uni_formset.html
@@ -1,0 +1,30 @@
+{% load crispy_forms_tags %}
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+{% if formset_tag %}
+<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+{% endif %}
+    {% if formset_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    <div>
+        {{ formset.management_form|crispy }}
+    </div>
+
+    {% include "bootstrap4/errors_formset.html" %}
+
+    {% for form in formset %}
+        {% include "bootstrap4/display_form.html" %}
+    {% endfor %}
+
+    {% if inputs %}
+        <div class="form-actions">
+            {% for input in inputs %}
+                {% include "bootstrap4/layout/baseinput.html" %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% if formset_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -114,7 +114,7 @@ class CrispyFieldNode(template.Node):
                 css_class = class_name
 
             if (
-                template_pack == 'bootstrap3'
+                template_pack in ['bootstrap3', 'bootstrap4']
                 and not is_checkbox(field)
                 and not is_file(field)
             ):

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -40,7 +40,7 @@ def as_crispy_form(form, template_pack=TEMPLATE_PACK, label_class="", field_clas
 
         {{ myform|crispy:"bootstrap" }}
 
-    In ``bootstrap3`` for horizontal forms you can do::
+    In ``bootstrap3`` or ``bootstrap4`` for horizontal forms you can do::
 
         {{ myform|label_class:"col-lg-2",field_class:"col-lg-8" }}
     """

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -277,7 +277,7 @@ def do_uni_form(parser, token):
         ALLOWED_TEMPLATE_PACKS = getattr(
             settings,
             'CRISPY_ALLOWED_TEMPLATE_PACKS',
-            ('bootstrap', 'uni_form', 'bootstrap3')
+            ('bootstrap', 'uni_form', 'bootstrap3', 'bootstrap4')
         )
         if template_pack not in ALLOWED_TEMPLATE_PACKS:
             raise template.TemplateSyntaxError(

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -5,8 +5,9 @@ from crispy_forms.layout import Layout, Div, Field, Submit, Fieldset, HTML
 
 
 only_uni_form = pytest.mark.only('uni_form')
-only_bootstrap = pytest.mark.only('bootstrap', 'bootstrap3')
+only_bootstrap = pytest.mark.only('bootstrap', 'bootstrap3', 'bootstrap4')
 only_bootstrap3 = pytest.mark.only('bootstrap3')
+only_bootstrap4 = pytest.mark.only('bootstrap4')
 
 
 @pytest.fixture
@@ -29,7 +30,8 @@ def advanced_layout():
     )
 
 
-@pytest.fixture(autouse=True, params=('uni_form', 'bootstrap', 'bootstrap3'))
+@pytest.fixture(autouse=True, params=('uni_form', 'bootstrap', 'bootstrap3',
+                                      'bootstrap4'))
 def template_packs(request, settings):
     check_template_pack(request._pyfuncitem._obj, request.param)
     settings.CRISPY_TEMPLATE_PACK = request.param

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -617,26 +617,28 @@ def test_template_pack():
 
 
 @only_bootstrap4
-def test_label_class_and_field_class():
+def test_bootstrap4_label_class_and_field_class():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.label_class = 'col-lg-2'
     form.helper.field_class = 'col-lg-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group row"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert html.count('<div class="form-group row">')
+    assert html.count('<div class="controls col-lg-offset-2 col-lg-8">')
     assert html.count('col-lg-8') == 7
 
     form.helper.label_class = 'col-sm-3'
     form.helper.field_class = 'col-sm-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group row"> <div class="controls col-sm-offset-3 col-sm-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert html.count('<div class="form-group row">')
+    assert html.count('<div class="controls col-sm-offset-3 col-sm-8">')
     assert html.count('col-sm-8') == 7
 
 
 @only_bootstrap4
-def test_template_pack():
+def test_bootstrap4_template_pack():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.template_pack = 'uni_form'

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -16,7 +16,7 @@ import pytest
 from django.utils.translation import ugettext_lazy as _
 
 from .compatibility import get_template_from_string
-from .conftest import only_uni_form, only_bootstrap3, only_bootstrap
+from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
 from .forms import TestForm
 from crispy_forms.bootstrap import (
     FieldWithButtons, PrependedAppendedText, AppendedText, PrependedText,
@@ -509,7 +509,7 @@ def test_error_text_inline(settings):
     html = render_crispy_form(form)
 
     help_class = 'help-inline'
-    if settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+    if settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
         help_class = 'help-block'
 
     matches = re.findall(
@@ -607,6 +607,35 @@ def test_label_class_and_field_class():
 
 
 @only_bootstrap3
+def test_template_pack():
+    form = TestForm()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'uni_form'
+    html = render_crispy_form(form)
+    assert 'form-control' not in html
+    assert 'ctrlHolder' in html
+
+
+@only_bootstrap4
+def test_label_class_and_field_class():
+    form = TestForm()
+    form.helper = FormHelper()
+    form.helper.label_class = 'col-lg-2'
+    form.helper.field_class = 'col-lg-8'
+    html = render_crispy_form(form)
+
+    assert '<div class="form-group row"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert html.count('col-lg-8') == 7
+
+    form.helper.label_class = 'col-sm-3'
+    form.helper.field_class = 'col-sm-8'
+    html = render_crispy_form(form)
+
+    assert '<div class="form-group row"> <div class="controls col-sm-offset-3 col-sm-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert html.count('col-sm-8') == 7
+
+
+@only_bootstrap4
 def test_template_pack():
     form = TestForm()
     form.helper = FormHelper()

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -624,16 +624,16 @@ def test_bootstrap4_label_class_and_field_class():
     form.helper.field_class = 'col-lg-8'
     html = render_crispy_form(form)
 
-    assert html.count('<div class="form-group row">')
-    assert html.count('<div class="controls col-lg-offset-2 col-lg-8">')
+    assert '<div class="form-group row">' in html
+    assert '<div class="controls col-lg-offset-2 col-lg-8">' in html
     assert html.count('col-lg-8') == 7
 
     form.helper.label_class = 'col-sm-3'
     form.helper.field_class = 'col-sm-8'
     html = render_crispy_form(form)
 
-    assert html.count('<div class="form-group row">')
-    assert html.count('<div class="controls col-sm-offset-3 col-sm-8">')
+    assert '<div class="form-group row">' in html
+    assert '<div class="controls col-sm-offset-3 col-sm-8">' in html
     assert html.count('col-sm-8') == 7
 
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -16,7 +16,7 @@ from django.test import RequestFactory
 from django.utils.translation import ugettext_lazy as _
 
 from .compatibility import get_template_from_string
-from .conftest import only_uni_form, only_bootstrap3, only_bootstrap
+from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
 from .forms import (
     TestForm, TestForm2, TestForm3, CheckboxesTestForm,
     TestForm4, CrispyTestModel, TestForm5
@@ -565,11 +565,32 @@ def test_keepcontext_context_manager(settings):
 
     if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
         assert response.content.count(b'checkbox inline') == 3
-    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+    elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
         assert response.content.count(b'checkbox-inline') == 3
 
 
 @only_bootstrap3
+def test_form_inline():
+    form = TestForm()
+    form.helper = FormHelper()
+    form.helper.form_class = 'form-inline'
+    form.helper.field_template = 'bootstrap3/layout/inline_field.html'
+    form.helper.layout = Layout(
+        'email',
+        'password1',
+        'last_name',
+    )
+
+    html = render_crispy_form(form)
+    assert html.count('class="form-inline"') == 1
+    assert html.count('class="form-group"') == 3
+    assert html.count('<label for="id_email" class="sr-only') == 1
+    assert html.count('id="div_id_email" class="form-group"') == 1
+    assert html.count('placeholder="email"') == 1
+    assert html.count('</label> <input') == 3
+
+
+@only_bootstrap4
 def test_form_inline():
     form = TestForm()
     form.helper = FormHelper()

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -312,6 +312,8 @@ def test_formset_layout(settings):
     assert html.count('Note for first form only') == 1
     if settings.CRISPY_TEMPLATE_PACK == 'uni_form':
         assert html.count('formRow') == 3
+    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+        assert html.count('row') == 21
     else:
         assert html.count('row') == 3
 
@@ -591,11 +593,11 @@ def test_form_inline():
 
 
 @only_bootstrap4
-def test_form_inline():
+def test_bootstrap4_form_inline():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.form_class = 'form-inline'
-    form.helper.field_template = 'bootstrap3/layout/inline_field.html'
+    form.helper.field_template = 'bootstrap4/layout/inline_field.html'
     form.helper.layout = Layout(
         'email',
         'password1',

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -97,6 +97,8 @@ def test_field_wrapper_class(settings):
         assert html.count('class="control-group testing"') == 1
     elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
         assert html.count('class="form-group testing"') == 1
+    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+        assert html.count('class="form-group testing"') == 1
 
 
 def test_html_with_carriage_returns(settings):
@@ -175,7 +177,7 @@ class TestBootstrapLayoutObjects(object):
             assert html.count('<span class="add-on">#</span>') == 1
             assert html.count('<span class="add-on">$</span>') == 1
 
-        if settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+        if settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
             assert html.count('<span class="input-group-addon">@</span>') == 1
             assert html.count('<span class="input-group-addon">gmail.com</span>') == 1
             assert html.count('<span class="input-group-addon">#</span>') == 1
@@ -191,7 +193,7 @@ class TestBootstrapLayoutObjects(object):
 
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
             assert html.count('radio inline"') == 2
-        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+        elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
             assert html.count('radio-inline"') == 2
 
     def test_accordion_and_accordiongroup(self, settings):
@@ -378,6 +380,8 @@ class TestBootstrapLayoutObjects(object):
         form_group_class = 'control-group'
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
             form_group_class = 'form-group'
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+            form_group_class = 'form-group'
 
         assert html.count('class="%s extra"' % form_group_class) == 1
         assert html.count('autocomplete="off"') == 1
@@ -393,7 +397,7 @@ class TestBootstrapLayoutObjects(object):
 
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
             assert html.count('class="input-append"') == 1
-        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+        elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
             assert html.count('class="input-group-btn') == 1
 
     def test_hidden_fields(self):
@@ -428,6 +432,6 @@ class TestBootstrapLayoutObjects(object):
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
             assert html.count('checkbox inline"') == 3
             assert html.count('inline"') == 3
-        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+        elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
             assert html.count('checkbox-inline"') == 3
             assert html.count('inline="True"') == 4

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -98,7 +98,7 @@ def test_field_wrapper_class(settings):
     elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
         assert html.count('class="form-group testing"') == 1
     elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
-        assert html.count('class="form-group testing"') == 1
+        assert html.count('class="form-group row testing"') == 1
 
 
 def test_html_with_carriage_returns(settings):
@@ -381,7 +381,7 @@ class TestBootstrapLayoutObjects(object):
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
             form_group_class = 'form-group'
         elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
-            form_group_class = 'form-group'
+            form_group_class = 'form-group row'
 
         assert html.count('class="%s extra"' % form_group_class) == 1
         assert html.count('autocomplete="off"') == 1

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -179,9 +179,26 @@ class TestBootstrapLayoutObjects(object):
 
         if settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
             assert html.count('<span class="input-group-addon">@</span>') == 1
-            assert html.count('<span class="input-group-addon">gmail.com</span>') == 1
+            assert html.count(
+                '<span class="input-group-addon">gmail.com</span>') == 1
             assert html.count('<span class="input-group-addon">#</span>') == 1
             assert html.count('<span class="input-group-addon">$</span>') == 1
+
+        if settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+            test_form.helper.layout = Layout(
+                PrependedAppendedText('email', '@', 'gmail.com',
+                                      css_class='input-lg'), )
+            html = render_crispy_form(test_form)
+
+            assert '<span class="input-group-addon input-lg' in html
+
+        if settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+            test_form.helper.layout = Layout(
+                PrependedAppendedText('email', '@', 'gmail.com',
+                                      css_class='form-control-lg'), )
+            html = render_crispy_form(test_form)
+
+            assert '<span class="input-group-addon form-control-lg' in html
 
     def test_inline_radios(self, settings):
         test_form = CheckboxesTestForm()

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -117,7 +117,7 @@ def test_crispy_addon(settings):
         # prepend and append tests
         assert "input-append" in crispy_addon(bound_field, prepend="Work", append="Primary")
         assert "input-prepend" in crispy_addon(bound_field, prepend="Work", append="Secondary")
-    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+    elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
         assert "input-group-addon" in crispy_addon(bound_field, prepend="Work", append="Primary")
         assert "input-group-addon" in crispy_addon(bound_field, prepend="Work", append="Secondary")
 


### PR DESCRIPTION
Closes https://github.com/maraujop/django-crispy-forms/issues/524

I was having issues with the tests for python 2.6 with old no longer 
maintained Django, but it didn't look related to anything I touched.

I also uncovered some tests for the bootstrap 3 support that don't 
actually test anything: https://github.com/maraujop/django-crispy-forms/issues/527
but I changed the similar tests for bootstrap4 to actually test for the 
right classes being set. 

In bootstrap3 .form-group included the .row class implicitly, but in
bootstrap4 it no longer includes .row, so I've added the .row class to
all form-group div's that allow labels and fields within the component
that could potentially have custom widths, which makes migrating
smoother, but I haven't thoroughly tested if it has unexpected issues.

http://v4-alpha.getbootstrap.com/migration/
