### PR TITLE
Fields not included in the explicit layout now render in the order they are provided

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 from crispy_forms.compatibility import string_types
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
-from crispy_forms.utils import render_field, flatatt, TEMPLATE_PACK
+from crispy_forms.utils import render_field, flatatt, TEMPLATE_PACK, list_intersection, list_difference
 from crispy_forms.exceptions import FormHelpersException
 
 
@@ -319,11 +319,11 @@ class FormHelper(DynamicLayoutHandler):
         # we suppose they need to be rendered
         if hasattr(form, 'Meta'):
             if hasattr(form.Meta, 'fields'):
-                current_fields = set(getattr(form, 'fields', []))
-                meta_fields = set(getattr(form.Meta, 'fields'))
+                current_fields = tuple(getattr(form, 'fields', {}).keys())
+                meta_fields = getattr(form.Meta, 'fields')
 
-                fields_to_render = current_fields & meta_fields
-                left_fields_to_render = fields_to_render - form.rendered_fields
+                fields_to_render = list_intersection(current_fields, meta_fields)
+                left_fields_to_render = list_difference(fields_to_render, form.rendered_fields)
 
                 for field in left_fields_to_render:
                     html += render_field(field, form, self.form_style, context)

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from crispy_forms.utils import list_union, list_difference, list_intersection
+
+
+def test_list_intersection():
+    assert list_intersection([1, 3], [2, 3]) == [3]
+
+
+def test_list_difference():
+    assert list_difference([3, 1, 2, 3], [4, 1, ]) == [3, 2]
+
+
+def test_list_set_operations():
+    list1 = ['3', '1', '4', '3']
+    list2 = ['2']
+    list3 = ['1', '6']
+    list4 = []
+    union = list_union(list1, list2, list3, list4)
+    assert union == ['3', '1', '4', '2', '6']
+    list5 = ['1', '3']
+    list6 = ['2', '3']
+    difference = list_difference(list5, list6)
+    assert difference == ['1']
+
+

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -190,3 +190,42 @@ def render_crispy_form(form, helper=None, context=None):
     })
 
     return node.render(node_context)
+
+
+def list_intersection(list1, list2):
+    """
+    Take the not-in-place intersection of two lists, similar to sets but preserving order.
+    Does not check unicity of list1.
+    """
+    intersection = []
+    for item in list1:
+        if item in list2:
+            intersection.append(item)
+    return intersection
+
+
+def list_union(*lists):
+    """
+    Take the not-in-place union of two or more lists, similar to sets but preserving order.
+    """
+    union = []
+    for li in lists:
+        for item in li:
+            if item not in union:
+                union.append(item)
+    return union
+
+
+def list_difference(left, right):
+    """
+    Take the not-in-place difference of two lists (left - right), similar to sets but preserving order.
+    """
+    blocked = set(right)
+    difference = []
+    for item in left:
+        if item not in blocked:
+            blocked.add(item)
+            difference.append(item)
+    return difference
+
+


### PR DESCRIPTION
Based on issue 538

Fields not included in the explicit layout now render in the order they are provided in `Form.Meta.fields` as one might expect.

This was achieved by replacing methods on sets of fields by corresponding methods on lists, to preserve order. These methods were implemented as two simple helper function. There is a matching (and passing) unit test.