### PR TITLE
Use TemplateNameMixin to get tmpl in bootstrap

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -182,7 +182,7 @@ class StrictButton(object):
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         self.content = Template(text_type(self.content)).render(context)
-        template = self.get_template_name(template_pack)
+        template = self.template % template_pack
         return render_to_string(template, {'button': self}, context)
 
 

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -36,7 +36,7 @@ class PrependedAppendedText(Field):
             'input_size': self.input_size,
             'active': getattr(self, "active", False)
         }
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_field(
             self.field, form, form_style, context,
             template=template, attrs=self.attrs,
@@ -86,7 +86,7 @@ class FormActions(LayoutObject):
             'formactions': self,
             'fields_output': html
         }
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_to_string(template, extra_context, context)
 
     def flat_attrs(self):
@@ -139,7 +139,7 @@ class FieldWithButtons(Div):
         )
 
         extra_context = {'div': self, 'buttons': buttons}
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
 
         if isinstance(self.fields[0], Field):
             # FieldWithButtons(Field('field_name'), StrictButton("go"))
@@ -182,7 +182,7 @@ class StrictButton(object):
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         self.content = Template(text_type(self.content)).render(context)
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_to_string(template, {'button': self}, context)
 
 
@@ -292,7 +292,7 @@ class TabHolder(ContainerHolder):
             'links': links,
             'content': content
         }
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_to_string(template, extra_context, context)
 
 
@@ -335,7 +335,7 @@ class Accordion(ContainerHolder):
                 group, form, form_style, context, template_pack=template_pack, **kwargs
             )
 
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_to_string(
             template,
             {'accordion': self, 'content': content},
@@ -362,7 +362,7 @@ class Alert(Div):
         self.dismiss = dismiss
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        template = self.template % template_pack
+        template = self.get_template_name(template_pack)
         return render_to_string(
             template,
             {'alert': self, 'content': self.content, 'dismiss': self.dismiss},


### PR DESCRIPTION
Issues like #361 or #448 warned about the `Exception Value: not all arguments converted during string formatting` error when overriding the template for `LayoutObject` and `BaseInput`, and were solved with commit 14745fd. I got the same problem while overriding objects from `bootstrap`such as `FieldWithButtons`because they were not using the `TemplateNameMixin.get_template_name` new method they were inheriting from.