### PR TITLE
Support wrapper_class in PrependedAppendedText

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -36,6 +36,8 @@ class PrependedAppendedText(Field):
             'input_size': self.input_size,
             'active': getattr(self, "active", False)
         }
+        if hasattr(self, 'wrapper_class'):
+            extra_context['wrapper_class'] = self.wrapper_class
         template = self.get_template_name(template_pack)
         return render_field(
             self.field, form, form_style, context,

--- a/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">


### PR DESCRIPTION
Very much taking its lead from the implementation of `Field` to put back the functionality in the subclass.

`PrependedAppendedText.__init__()` calls `super` so doesn't need this functionality putting back, but `render()` doesn't call `super` and the template doesn't extend from the `Field` template.