### PR TITLE
Bootstrap4: control-label -> form-control-label

### DIFF
--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -11,7 +11,7 @@
     {% endif %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% if using_grid_layout %} row{% endif %}{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
-            <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.auto_id }}"  class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -2,7 +2,7 @@
 
 <div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
-        <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+        <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -6,7 +6,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
-            <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.auto_id }}"  class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -2,7 +2,7 @@
 
 
 <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-    <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
+    <label class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
     <div class="controls {{ field_class }}">
         {% crispy_field field 'disabled' 'disabled' %}
         {% include 'bootstrap4/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap4/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap4/table_inline_formset.html
@@ -21,7 +21,7 @@
                 <tr>
                     {% for field in formset.forms.0 %}
                         {% if field.label and not field|is_checkbox and not field.is_hidden %}
-                            <th for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
+                            <th for="{{ field.auto_id }}" class="form-control-label {% if field.field.required %}requiredField{% endif %}">
                                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                             </th>
                         {% endif %}


### PR DESCRIPTION
From the Bootstrap4 migration guide:
- Rename .control-label to .form-control-label

I updated the bootstrap4 templates as required, please merge.

Thanks
Gert
