### PR TITLE
Use hassattr instead of try/catch block.

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -113,11 +113,8 @@ class BasicNode(template.Node):
             helper = FormHelper() if not hasattr(actual_form, 'helper') else actual_form.helper
 
         # use template_pack from helper, if defined
-        try:
-            if helper.template_pack:
-                self.template_pack = helper.template_pack
-        except AttributeError:
-            pass
+        if hasattr(helper, 'template_pack') and helper.template_pack:
+            self.template_pack = helper.template_pack
 
         self.actual_helper = helper
 


### PR DESCRIPTION
I think that is much cleaner than try/catch and this change fix error:

	  File "/srv/leonardo/sites/kzcars/local/lib/python2.7/site-packages/crispy_forms/templatetags/crispy_forms_tags.py", line 117, in get_render
	    if helper.template_pack:
	AttributeError: 'FormHelper' object has no attribute 'template_pack'

related to https://github.com/django-leonardo/django-leonardo/issues/156 which was caused by upgrade from 1.4.0