### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Django-crispy-forms supports several frontend frameworks, such as Twitter `Boots
 
 .. _`Uni-form`: http://sprawsm.com/uni-form
 .. _`Bootstrap`: http://twitter.github.com/bootstrap/index.html
-.. _`see the docs`: http://django-crispy-forms.rtfd.org
+.. _`see the docs`: https://django-crispy-forms.readthedocs.io
 
 Authors
 =======
@@ -35,7 +35,7 @@ If you are upgrading from django-uni-form, we have `instructions`_ for helping y
 
 .. _`Daniel Greenfeld`: https://github.com/pydanny
 .. _`Miguel Araujo`: https://github.com/maraujop
-.. _`instructions`: http://django-crispy-forms.readthedocs.io/en/latest/install.html#moving-from-django-uni-form-to-django-crispy-forms
+.. _`instructions`: https://django-crispy-forms.readthedocs.io/en/latest/install.html#moving-from-django-uni-form-to-django-crispy-forms
 
 Example
 =======
@@ -51,7 +51,7 @@ Documentation
 
 For extensive documentation see the ``docs`` folder or `read it on readthedocs`_
 
-.. _`read it on readthedocs`: http://django-crispy-forms.readthedocs.org/en/latest/index.html
+.. _`read it on readthedocs`: https://django-crispy-forms.readthedocs.io/en/latest/index.html
 
 Special thanks
 ==============

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -14,7 +14,7 @@
     If you love django-crispy-forms, consider making a small donation <a href="http://flattr.com/thing/512037/django-crispy-forms">on Flattr</a>:
 </p>
 <p>
-    <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://django-crispy-forms.rtfd.org"></a>
+    <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="https://django-crispy-forms.readthedocs.io"></a>
     <noscript><a href="http://flattr.com/thing/512037/django-crispy-forms" target="_blank">
     <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Click to flattr django-crispy-forms" border="0" /></a></noscript>
 </p>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.